### PR TITLE
OSMEA - Package - API -> Network products smart collections

### DIFF
--- a/packages/apis/example/lib/services/api_service_registry.dart
+++ b/packages/apis/example/lib/services/api_service_registry.dart
@@ -181,6 +181,7 @@ import 'package:example/services/handlers/smart_collection_handlers/retrieves_co
 import 'package:example/services/handlers/smart_collection_handlers/updates_existing_smart_collection_handler.dart';
 import 'package:example/services/handlers/smart_collection_handlers/updates_ordering_type_of_products_smart_collection_handler.dart';
 import 'package:example/services/handlers/smart_collection_handlers/delete_smart_collection_handler.dart';
+import 'package:example/services/handlers/smart_collection_handlers/create_smart_collection_handler.dart';
 
 enum ApiCategory {
   access,
@@ -1795,6 +1796,14 @@ ApiService(
   category: ApiCategory.Products,
   subcategory: 'Smart Collection',
   handler: DeletesSmartCollectionHandler(),
+),
+
+ApiService(
+  name: 'Create Smart Collection',
+  endpoint: '/smart_collections',
+  category: ApiCategory.Products,
+  subcategory: 'Smart Collection',  
+  handler: CreatesSmartCollectionHandler(),
 ),
   ];
 

--- a/packages/apis/example/lib/services/api_service_registry.dart
+++ b/packages/apis/example/lib/services/api_service_registry.dart
@@ -180,6 +180,7 @@ import 'package:example/services/handlers/smart_collection_handlers/retrieves_si
 import 'package:example/services/handlers/smart_collection_handlers/retrieves_count_of_smart_collections_handler.dart';
 import 'package:example/services/handlers/smart_collection_handlers/updates_existing_smart_collection_handler.dart';
 import 'package:example/services/handlers/smart_collection_handlers/updates_ordering_type_of_products_smart_collection_handler.dart';
+import 'package:example/services/handlers/smart_collection_handlers/delete_smart_collection_handler.dart';
 
 enum ApiCategory {
   access,
@@ -1786,6 +1787,14 @@ ApiService(
   category: ApiCategory.Products,
   subcategory: 'Smart Collection',
   handler: UpdateProductOrderHandler(),
+),
+
+ApiService(
+  name: 'Delete Smart Collection',
+  endpoint: '/smart_collections/:id',
+  category: ApiCategory.Products,
+  subcategory: 'Smart Collection',
+  handler: DeletesSmartCollectionHandler(),
 ),
   ];
 

--- a/packages/apis/example/lib/services/api_service_registry.dart
+++ b/packages/apis/example/lib/services/api_service_registry.dart
@@ -178,7 +178,8 @@ import 'package:example/services/handlers/webhooks_handlers/webhook_handlers/del
 import 'package:example/services/handlers/smart_collection_handlers/retrieves_list_of_smart_collections_handler.dart';
 import 'package:example/services/handlers/smart_collection_handlers/retrieves_single_smart_collection_handler.dart';
 import 'package:example/services/handlers/smart_collection_handlers/retrieves_count_of_smart_collections_handler.dart';
-
+import 'package:example/services/handlers/smart_collection_handlers/updates_existing_smart_collection_handler.dart';
+import 'package:example/services/handlers/smart_collection_handlers/updates_ordering_type_of_products_smart_collection_handler.dart';
 
 enum ApiCategory {
   access,
@@ -1770,6 +1771,21 @@ ApiService(
   category: ApiCategory.Products,
   subcategory: 'Smart Collection',
   handler: RetrieveCountOfSmartCollectionsHandler(),
+),
+
+ApiService(
+  name: 'Update Smart Collection',
+  endpoint: '/smart_collections/:id',
+  category: ApiCategory.Products,
+  subcategory: 'Smart Collection',
+  handler: UpdatesSmartCollectionHandler(),
+),
+ApiService(
+  name: 'Update Product Order in Smart Collection',
+  endpoint: '/smart_collections/:id/order',
+  category: ApiCategory.Products,
+  subcategory: 'Smart Collection',
+  handler: UpdateProductOrderHandler(),
 ),
   ];
 

--- a/packages/apis/example/lib/services/api_service_registry.dart
+++ b/packages/apis/example/lib/services/api_service_registry.dart
@@ -176,6 +176,7 @@ import 'package:example/services/handlers/webhooks_handlers/webhook_handlers/cre
 import 'package:example/services/handlers/webhooks_handlers/webhook_handlers/update_webhook_handler.dart';
 import 'package:example/services/handlers/webhooks_handlers/webhook_handlers/delete_webhook_handler.dart';
 import 'package:example/services/handlers/smart_collection_handlers/retrieves_list_of_smart_collections_handler.dart';
+import 'package:example/services/handlers/smart_collection_handlers/retrieves_single_smart_collection_handler.dart';
 
 
 enum ApiCategory {
@@ -1752,6 +1753,14 @@ class ApiServiceRegistry {
   category: ApiCategory.Products,
   subcategory: 'Smart Collection',
   handler: RetrievesAllSmartCollectionsHandler(),
+),
+
+ApiService(
+  name: 'Get Single Smart Collection',
+  endpoint: '/smart_collections/:id',
+  category: ApiCategory.Products,
+  subcategory: 'Smart Collection', 
+  handler: RetrieveSingleSmartCollectionHandler(),
 ),
   ];
 

--- a/packages/apis/example/lib/services/api_service_registry.dart
+++ b/packages/apis/example/lib/services/api_service_registry.dart
@@ -175,6 +175,8 @@ import 'package:example/services/handlers/webhooks_handlers/webhook_handlers/ret
 import 'package:example/services/handlers/webhooks_handlers/webhook_handlers/create_webhook_handler.dart';
 import 'package:example/services/handlers/webhooks_handlers/webhook_handlers/update_webhook_handler.dart';
 import 'package:example/services/handlers/webhooks_handlers/webhook_handlers/delete_webhook_handler.dart';
+import 'package:example/services/handlers/smart_collection_handlers/retrieves_list_of_smart_collections_handler.dart';
+
 
 enum ApiCategory {
   access,
@@ -192,7 +194,8 @@ enum ApiCategory {
   storeProperties,
   onlineStore,
   tendertransaction,
-  webhooks
+  webhooks,
+  Products
 }
 
 extension ApiCategoryExtension on ApiCategory {
@@ -230,6 +233,9 @@ extension ApiCategoryExtension on ApiCategory {
         return 'Tender Transaction APIs';
       case ApiCategory.webhooks:
         return 'Webhooks APIs';
+        case ApiCategory.Products:
+        return 'Products APIs';
+        
     }
   }
 }
@@ -1739,6 +1745,14 @@ class ApiServiceRegistry {
       subcategory: 'Webhook',
       handler: DeleteWebhookHandler(),
     ),
+
+    ApiService(
+  name: 'List Smart Collections',
+  endpoint: '/smart_collections',
+  category: ApiCategory.Products,
+  subcategory: 'Smart Collection',
+  handler: RetrievesAllSmartCollectionsHandler(),
+),
   ];
 
   static void initialize() {}
@@ -1799,6 +1813,8 @@ class ApiServiceRegistry {
         return 'Tender Transaction';
       case ApiCategory.webhooks:
         return 'Webhooks';
+        case ApiCategory.Products:
+        return 'Smart Collection';
     }
   }
 }

--- a/packages/apis/example/lib/services/api_service_registry.dart
+++ b/packages/apis/example/lib/services/api_service_registry.dart
@@ -1764,7 +1764,7 @@ ApiService(
   endpoint: '/smart_collections/:id',
   category: ApiCategory.Products,
   subcategory: 'Smart Collection', 
-  handler: RetrieveSingleSmartCollectionHandler(),
+  handler: RetrievesSingleSmartCollectionHandler(),
 ),
 
 ApiService(

--- a/packages/apis/example/lib/services/api_service_registry.dart
+++ b/packages/apis/example/lib/services/api_service_registry.dart
@@ -177,6 +177,7 @@ import 'package:example/services/handlers/webhooks_handlers/webhook_handlers/upd
 import 'package:example/services/handlers/webhooks_handlers/webhook_handlers/delete_webhook_handler.dart';
 import 'package:example/services/handlers/smart_collection_handlers/retrieves_list_of_smart_collections_handler.dart';
 import 'package:example/services/handlers/smart_collection_handlers/retrieves_single_smart_collection_handler.dart';
+import 'package:example/services/handlers/smart_collection_handlers/retrieves_count_of_smart_collections_handler.dart';
 
 
 enum ApiCategory {
@@ -1761,6 +1762,14 @@ ApiService(
   category: ApiCategory.Products,
   subcategory: 'Smart Collection', 
   handler: RetrieveSingleSmartCollectionHandler(),
+),
+
+ApiService(
+  name: 'Count Smart Collections',
+  endpoint: '/smart_collections/count',
+  category: ApiCategory.Products,
+  subcategory: 'Smart Collection',
+  handler: RetrieveCountOfSmartCollectionsHandler(),
 ),
   ];
 

--- a/packages/apis/example/lib/services/handlers/smart_collection_handlers/create_smart_collection_handler.dart
+++ b/packages/apis/example/lib/services/handlers/smart_collection_handlers/create_smart_collection_handler.dart
@@ -1,0 +1,77 @@
+import 'dart:convert';
+
+import 'package:apis/apis.dart';
+import 'package:apis/network/remote/smart_collections/abstract/smart_collection_service.dart';
+import 'package:apis/network/remote/smart_collections/freezed_model/request/create_smart_collection_request.dart';
+import 'package:example/services/api_request_handler.dart';
+import 'package:example/services/api_service_registry.dart';
+import 'package:get_it/get_it.dart';
+
+///**************************************************************
+///************* 🆕 CREATES SMART COLLECTION HANDLER *************
+///**************************************************************
+
+class CreatesSmartCollectionHandler implements ApiRequestHandler {
+  @override
+  Future<Map<String, dynamic>> handleRequest(
+    String method,
+    Map<String, String> params,
+  ) async {
+    if (method != 'POST') {
+      return {
+        'status': 'error',
+        'message': 'Method $method not supported. Only POST is allowed.',
+        'timestamp': DateTime.now().toIso8601String(),
+      };
+    }
+
+    try {
+      final rawBody = params['body'];
+      if (rawBody == null) {
+        return {
+          'status': 'error',
+          'message': 'Missing request body.',
+          'timestamp': DateTime.now().toIso8601String(),
+        };
+      }
+
+      final decodedJson = json.decode(rawBody) as Map<String, dynamic>;
+      final request = CreateSmartCollectionRequest.fromJson(decodedJson);
+
+      final response =
+          await GetIt.I<SmartCollectionService>().createSmartCollection(
+        apiVersion: ApiNetwork.apiVersion,
+        request: request,
+      );
+
+      return {
+        'status': 'success',
+        'data': response.toJson(),
+        'timestamp': DateTime.now().toIso8601String(),
+      };
+    } catch (e) {
+      return {
+        'status': 'error',
+        'message': 'Failed to create smart collection: ${e.toString()}',
+        'timestamp': DateTime.now().toIso8601String(),
+      };
+    }
+  }
+
+  @override
+  List<String> get supportedMethods => ['POST'];
+
+  @override
+  Map<String, List<ApiField>> get requiredFields => {
+        'POST': [
+          ApiField(
+            name: 'body',
+            type: ApiFieldType.text,
+            isRequired: true,
+            label: 'Request Body',
+            hint:
+                'The JSON body of the request containing smart collection details',
+          ),
+        ],
+      };
+}

--- a/packages/apis/example/lib/services/handlers/smart_collection_handlers/delete_smart_collection_handler.dart
+++ b/packages/apis/example/lib/services/handlers/smart_collection_handlers/delete_smart_collection_handler.dart
@@ -1,0 +1,69 @@
+import 'package:apis/apis.dart';
+import 'package:apis/network/remote/smart_collections/abstract/smart_collection_service.dart';
+import 'package:example/services/api_request_handler.dart';
+import 'package:example/services/api_service_registry.dart';
+import 'package:get_it/get_it.dart';
+
+///**************************************************************
+///************* ❌ DELETES SMART COLLECTION HANDLER *************
+///**************************************************************
+
+class DeletesSmartCollectionHandler implements ApiRequestHandler {
+  @override
+  Future<Map<String, dynamic>> handleRequest(
+    String method,
+    Map<String, String> params,
+  ) async {
+    if (method != 'DELETE') {
+      return {
+        'status': 'error',
+        'message': 'Method $method not supported. Only DELETE is allowed.',
+        'timestamp': DateTime.now().toIso8601String(),
+      };
+    }
+
+    final id = params['id'];
+    if (id == null || id.isEmpty) {
+      return {
+        'status': 'error',
+        'message': 'Missing required parameter: id',
+        'timestamp': DateTime.now().toIso8601String(),
+      };
+    }
+
+    try {
+      await GetIt.I<SmartCollectionService>().deleteSmartCollection(
+        apiVersion: ApiNetwork.apiVersion,
+        id: id,
+      );
+
+      return {
+        'status': 'success',
+        'message': 'Smart collection with ID $id deleted successfully.',
+        'timestamp': DateTime.now().toIso8601String(),
+      };
+    } catch (e) {
+      return {
+        'status': 'error',
+        'message': 'Failed to delete smart collection: ${e.toString()}',
+        'timestamp': DateTime.now().toIso8601String(),
+      };
+    }
+  }
+
+  @override
+  List<String> get supportedMethods => ['DELETE'];
+
+  @override
+  Map<String, List<ApiField>> get requiredFields => {
+        'DELETE': [
+          ApiField(
+            name: 'id',
+            type: ApiFieldType.text,
+            isRequired: true,
+            label: 'Smart Collection ID',
+            hint: 'The unique ID of the smart collection to delete',
+          ),
+        ],
+      };
+}

--- a/packages/apis/example/lib/services/handlers/smart_collection_handlers/retrieves_count_of_smart_collections_handler.dart
+++ b/packages/apis/example/lib/services/handlers/smart_collection_handlers/retrieves_count_of_smart_collections_handler.dart
@@ -26,6 +26,13 @@ class RetrieveCountOfSmartCollectionsHandler implements ApiRequestHandler {
       final response =
           await GetIt.I<SmartCollectionService>().countSmartCollections(
         apiVersion: ApiNetwork.apiVersion,
+        title: params['title'],
+        productId: params['product_id'],
+        updatedAtMin: params['updated_at_min'],
+        updatedAtMax: params['updated_at_max'],
+        publishedAtMin: params['published_at_min'],
+        publishedAtMax: params['published_at_max'],
+        publishedStatus: params['published_status'],
       );
 
       return {
@@ -48,6 +55,56 @@ class RetrieveCountOfSmartCollectionsHandler implements ApiRequestHandler {
 
   @override
   Map<String, List<ApiField>> get requiredFields => {
-        'GET': [],
+        'GET': [
+          ApiField(
+            name: 'title',
+            type: ApiFieldType.text,
+            isRequired: false,
+            label: 'Title',
+            hint: 'Filter by collection title',
+          ),
+          ApiField(
+            name: 'product_id',
+            type: ApiFieldType.text,
+            isRequired: false,
+            label: 'Product ID',
+            hint: 'Filter by product ID',
+          ),
+          ApiField(
+            name: 'updated_at_min',
+            type: ApiFieldType.text,
+            isRequired: false,
+            label: 'Updated At Min',
+            hint: 'Show collections updated after this date',
+          ),
+          ApiField(
+            name: 'updated_at_max',
+            type: ApiFieldType.text,
+            isRequired: false,
+            label: 'Updated At Max',
+            hint: 'Show collections updated before this date',
+          ),
+          ApiField(
+            name: 'published_at_min',
+            type: ApiFieldType.text,
+            isRequired: false,
+            label: 'Published At Min',
+            hint: 'Show collections published after this date',
+          ),
+          ApiField(
+            name: 'published_at_max',
+            type: ApiFieldType.text,
+            isRequired: false,
+            label: 'Published At Max',
+            hint: 'Show collections published before this date',
+          ),
+          ApiField(
+            name: 'published_status',
+            type: ApiFieldType.text,
+            isRequired: false,
+            label: 'Published Status',
+            hint: 'Filter by published status (published, unpublished, any)',
+          ),
+        ],
       };
 }

--- a/packages/apis/example/lib/services/handlers/smart_collection_handlers/retrieves_count_of_smart_collections_handler.dart
+++ b/packages/apis/example/lib/services/handlers/smart_collection_handlers/retrieves_count_of_smart_collections_handler.dart
@@ -1,0 +1,53 @@
+import 'package:apis/apis.dart';
+import 'package:apis/network/remote/smart_collections/abstract/smart_collection_service.dart';
+import 'package:example/services/api_request_handler.dart';
+import 'package:example/services/api_service_registry.dart';
+import 'package:get_it/get_it.dart';
+
+///**************************************************************
+///*********** 🔢 COUNT OF SMART COLLECTIONS HANDLER ************
+///**************************************************************
+
+class RetrieveCountOfSmartCollectionsHandler implements ApiRequestHandler {
+  @override
+  Future<Map<String, dynamic>> handleRequest(
+    String method,
+    Map<String, String> params,
+  ) async {
+    if (method != 'GET') {
+      return {
+        'status': 'error',
+        'message': 'Method $method not supported. Only GET is allowed.',
+        'timestamp': DateTime.now().toIso8601String(),
+      };
+    }
+
+    try {
+      final response =
+          await GetIt.I<SmartCollectionService>().countSmartCollections(
+        apiVersion: ApiNetwork.apiVersion,
+      );
+
+      return {
+        'status': 'success',
+        'data': response.toJson(),
+        'timestamp': DateTime.now().toIso8601String(),
+      };
+    } catch (e) {
+      return {
+        'status': 'error',
+        'message':
+            'Failed to retrieve smart collections count: ${e.toString()}',
+        'timestamp': DateTime.now().toIso8601String(),
+      };
+    }
+  }
+
+  @override
+  List<String> get supportedMethods => ['GET'];
+
+  @override
+  Map<String, List<ApiField>> get requiredFields => {
+        'GET': [],
+      };
+}

--- a/packages/apis/example/lib/services/handlers/smart_collection_handlers/retrieves_list_of_smart_collections_handler.dart
+++ b/packages/apis/example/lib/services/handlers/smart_collection_handlers/retrieves_list_of_smart_collections_handler.dart
@@ -2,7 +2,6 @@ import 'package:apis/apis.dart';
 import 'package:apis/network/remote/smart_collections/abstract/smart_collection_service.dart';
 import 'package:example/services/api_request_handler.dart';
 import 'package:example/services/api_service_registry.dart';
-
 import 'package:get_it/get_it.dart';
 
 ///**************************************************************
@@ -30,6 +29,15 @@ class RetrievesAllSmartCollectionsHandler implements ApiRequestHandler {
         limit: params['limit'] != null ? int.tryParse(params['limit']!) : null,
         sinceId: params['since_id'],
         fields: params['fields'],
+        ids: params['ids'],
+        title: params['title'],
+        handle: params['handle'],
+        productId: params['product_id'],
+        updatedAtMin: params['updated_at_min'],
+        updatedAtMax: params['updated_at_max'],
+        publishedAtMin: params['published_at_min'],
+        publishedAtMax: params['published_at_max'],
+        publishedStatus: params['published_status'],
       );
 
       return {
@@ -51,6 +59,91 @@ class RetrievesAllSmartCollectionsHandler implements ApiRequestHandler {
 
   @override
   Map<String, List<ApiField>> get requiredFields => {
-        'GET': [], 
+        'GET': [
+          ApiField(
+            name: 'limit',
+            type: ApiFieldType.text,
+            isRequired: false,
+            label: 'Limit',
+            hint: 'Maximum number of results (1-250)',
+          ),
+          ApiField(
+            name: 'since_id',
+            type: ApiFieldType.text,
+            isRequired: false,
+            label: 'Since ID',
+            hint: 'Show collections after specified ID',
+          ),
+          ApiField(
+            name: 'fields',
+            type: ApiFieldType.text,
+            isRequired: false,
+            label: 'Fields',
+            hint: 'Comma-separated list of fields to include',
+          ),
+          ApiField(
+            name: 'ids',
+            type: ApiFieldType.text,
+            isRequired: false,
+            label: 'IDs',
+            hint: 'Comma-separated list of collection IDs',
+          ),
+          ApiField(
+            name: 'title',
+            type: ApiFieldType.text,
+            isRequired: false,
+            label: 'Title',
+            hint: 'Filter by collection title',
+          ),
+          ApiField(
+            name: 'handle',
+            type: ApiFieldType.text,
+            isRequired: false,
+            label: 'Handle',
+            hint: 'Filter by collection handle',
+          ),
+          ApiField(
+            name: 'product_id',
+            type: ApiFieldType.text,
+            isRequired: false,
+            label: 'Product ID',
+            hint: 'Filter by product ID',
+          ),
+          ApiField(
+            name: 'updated_at_min',
+            type: ApiFieldType.text,
+            isRequired: false,
+            label: 'Updated At Min',
+            hint: 'Show collections updated after this date',
+          ),
+          ApiField(
+            name: 'updated_at_max',
+            type: ApiFieldType.text,
+            isRequired: false,
+            label: 'Updated At Max',
+            hint: 'Show collections updated before this date',
+          ),
+          ApiField(
+            name: 'published_at_min',
+            type: ApiFieldType.text,
+            isRequired: false,
+            label: 'Published At Min',
+            hint: 'Show collections published after this date',
+          ),
+          ApiField(
+            name: 'published_at_max',
+            type: ApiFieldType.text,
+            isRequired: false,
+            label: 'Published At Max',
+            hint: 'Show collections published before this date',
+          ),
+          ApiField(
+            name: 'published_status',
+            type: ApiFieldType.text,
+            isRequired: false,
+            label: 'Published Status',
+            hint: 'Filter by published status (published, unpublished, any)',
+          ),
+        ],
       };
 }

--- a/packages/apis/example/lib/services/handlers/smart_collection_handlers/retrieves_list_of_smart_collections_handler.dart
+++ b/packages/apis/example/lib/services/handlers/smart_collection_handlers/retrieves_list_of_smart_collections_handler.dart
@@ -1,0 +1,56 @@
+import 'package:apis/apis.dart';
+import 'package:apis/network/remote/smart_collections/abstract/smart_collection_service.dart';
+import 'package:example/services/api_request_handler.dart';
+import 'package:example/services/api_service_registry.dart';
+
+import 'package:get_it/get_it.dart';
+
+///**************************************************************
+///********** 🧠 RETRIEVE LIST OF SMART COLLECTIONS *************
+///**************************************************************
+
+class RetrievesAllSmartCollectionsHandler implements ApiRequestHandler {
+  @override
+  Future<Map<String, dynamic>> handleRequest(
+    String method,
+    Map<String, String> params,
+  ) async {
+    if (method != 'GET') {
+      return {
+        'status': 'error',
+        'message': 'Method $method not supported. Only GET is allowed.',
+        'timestamp': DateTime.now().toIso8601String(),
+      };
+    }
+
+    try {
+      final response =
+          await GetIt.I<SmartCollectionService>().listSmartCollections(
+        apiVersion: ApiNetwork.apiVersion,
+        limit: params['limit'] != null ? int.tryParse(params['limit']!) : null,
+        sinceId: params['since_id'],
+        fields: params['fields'],
+      );
+
+      return {
+        'status': 'success',
+        'data': response.toJson(),
+        'timestamp': DateTime.now().toIso8601String(),
+      };
+    } catch (e) {
+      return {
+        'status': 'error',
+        'message': 'Failed to retrieve smart collections: ${e.toString()}',
+        'timestamp': DateTime.now().toIso8601String(),
+      };
+    }
+  }
+
+  @override
+  List<String> get supportedMethods => ['GET'];
+
+  @override
+  Map<String, List<ApiField>> get requiredFields => {
+        'GET': [], 
+      };
+}

--- a/packages/apis/example/lib/services/handlers/smart_collection_handlers/retrieves_single_smart_collection_handler.dart
+++ b/packages/apis/example/lib/services/handlers/smart_collection_handlers/retrieves_single_smart_collection_handler.dart
@@ -1,0 +1,70 @@
+import 'package:apis/apis.dart';
+import 'package:apis/network/remote/smart_collections/abstract/smart_collection_service.dart';
+import 'package:example/services/api_request_handler.dart';
+import 'package:example/services/api_service_registry.dart';
+import 'package:get_it/get_it.dart';
+
+///**************************************************************
+///********* 🧠 RETRIEVE SINGLE SMART COLLECTION BY ID **********
+///**************************************************************
+
+class RetrieveSingleSmartCollectionHandler implements ApiRequestHandler {
+  @override
+  Future<Map<String, dynamic>> handleRequest(
+    String method,
+    Map<String, String> params,
+  ) async {
+    if (method != 'GET') {
+      return {
+        'status': 'error',
+        'message': 'Method $method not supported. Only GET is allowed.',
+        'timestamp': DateTime.now().toIso8601String(),
+      };
+    }
+
+    final id = params['id'];
+    if (id == null || id.isEmpty) {
+      return {
+        'status': 'error',
+        'message': 'Missing required parameter: id',
+        'timestamp': DateTime.now().toIso8601String(),
+      };
+    }
+
+    try {
+      final response =
+          await GetIt.I<SmartCollectionService>().retrieveSingleSmartCollection(
+        apiVersion: ApiNetwork.apiVersion,
+        id: id,
+      );
+
+      return {
+        'status': 'success',
+        'data': response.toJson(),
+        'timestamp': DateTime.now().toIso8601String(),
+      };
+    } catch (e) {
+      return {
+        'status': 'error',
+        'message': 'Failed to retrieve smart collection: ${e.toString()}',
+        'timestamp': DateTime.now().toIso8601String(),
+      };
+    }
+  }
+
+  @override
+  List<String> get supportedMethods => ['GET'];
+
+  @override
+  Map<String, List<ApiField>> get requiredFields => {
+        'GET': [
+          ApiField(
+            name: 'id',
+            type: ApiFieldType.text,
+            isRequired: true,
+            label: 'Smart Collection ID',
+            hint: 'The unique identifier for the smart collection',
+          ),
+        ],
+      };
+}

--- a/packages/apis/example/lib/services/handlers/smart_collection_handlers/retrieves_single_smart_collection_handler.dart
+++ b/packages/apis/example/lib/services/handlers/smart_collection_handlers/retrieves_single_smart_collection_handler.dart
@@ -5,10 +5,10 @@ import 'package:example/services/api_service_registry.dart';
 import 'package:get_it/get_it.dart';
 
 ///**************************************************************
-///********* 🧠 RETRIEVE SINGLE SMART COLLECTION BY ID **********
+///****** 📄 RETRIEVE SINGLE SMART COLLECTION HANDLER **********
 ///**************************************************************
 
-class RetrieveSingleSmartCollectionHandler implements ApiRequestHandler {
+class RetrievesSingleSmartCollectionHandler implements ApiRequestHandler {
   @override
   Future<Map<String, dynamic>> handleRequest(
     String method,
@@ -23,6 +23,8 @@ class RetrieveSingleSmartCollectionHandler implements ApiRequestHandler {
     }
 
     final id = params['id'];
+    final fields = params['fields'];
+
     if (id == null || id.isEmpty) {
       return {
         'status': 'error',
@@ -36,6 +38,7 @@ class RetrieveSingleSmartCollectionHandler implements ApiRequestHandler {
           await GetIt.I<SmartCollectionService>().retrieveSingleSmartCollection(
         apiVersion: ApiNetwork.apiVersion,
         id: id,
+        fields: fields,
       );
 
       return {
@@ -63,7 +66,14 @@ class RetrieveSingleSmartCollectionHandler implements ApiRequestHandler {
             type: ApiFieldType.text,
             isRequired: true,
             label: 'Smart Collection ID',
-            hint: 'The unique identifier for the smart collection',
+            hint: 'The ID of the smart collection to retrieve',
+          ),
+          ApiField(
+            name: 'fields',
+            type: ApiFieldType.text,
+            isRequired: false,
+            label: 'Fields',
+            hint: 'Comma-separated fields to include (e.g. id,title,handle)',
           ),
         ],
       };

--- a/packages/apis/example/lib/services/handlers/smart_collection_handlers/updates_existing_smart_collection_handler.dart
+++ b/packages/apis/example/lib/services/handlers/smart_collection_handlers/updates_existing_smart_collection_handler.dart
@@ -1,0 +1,95 @@
+import 'dart:convert';
+
+import 'package:apis/apis.dart';
+import 'package:apis/network/remote/smart_collections/abstract/smart_collection_service.dart';
+import 'package:apis/network/remote/smart_collections/freezed_model/request/updates_existing_smart_collection_request.dart';
+import 'package:example/services/api_request_handler.dart';
+import 'package:example/services/api_service_registry.dart';
+
+import 'package:get_it/get_it.dart';
+
+///**************************************************************
+///************ ✏ UPDATES SMART COLLECTION HANDLER *************
+///**************************************************************
+
+class UpdatesSmartCollectionHandler implements ApiRequestHandler {
+  @override
+  Future<Map<String, dynamic>> handleRequest(
+    String method,
+    Map<String, String> params,
+  ) async {
+    if (method != 'PUT') {
+      return {
+        'status': 'error',
+        'message': 'Method $method not supported. Only PUT is allowed.',
+        'timestamp': DateTime.now().toIso8601String(),
+      };
+    }
+
+    final id = params['id'];
+    final rawBody = params['body'];
+
+    if (id == null || id.isEmpty) {
+      return {
+        'status': 'error',
+        'message': 'Missing required parameter: id',
+        'timestamp': DateTime.now().toIso8601String(),
+      };
+    }
+
+    if (rawBody == null || rawBody.isEmpty) {
+      return {
+        'status': 'error',
+        'message': 'Missing request body.',
+        'timestamp': DateTime.now().toIso8601String(),
+      };
+    }
+
+    try {
+      final decodedJson = json.decode(rawBody) as Map<String, dynamic>;
+      final request = UpdateSmartCollectionRequest.fromJson(decodedJson);
+
+      final response =
+          await GetIt.I<SmartCollectionService>().updateSmartCollection(
+        apiVersion: ApiNetwork.apiVersion,
+        id: id,
+        request: request,
+      );
+
+      return {
+        'status': 'success',
+        'data': response.toJson(),
+        'timestamp': DateTime.now().toIso8601String(),
+      };
+    } catch (e) {
+      return {
+        'status': 'error',
+        'message': 'Failed to update smart collection: ${e.toString()}',
+        'timestamp': DateTime.now().toIso8601String(),
+      };
+    }
+  }
+
+  @override
+  List<String> get supportedMethods => ['PUT'];
+
+  @override
+  Map<String, List<ApiField>> get requiredFields => {
+        'PUT': [
+          ApiField(
+            name: 'id',
+            type: ApiFieldType.text,
+            isRequired: true,
+            label: 'Smart Collection ID',
+            hint: 'The ID of the smart collection you want to update',
+          ),
+          ApiField(
+            name: 'body',
+            type: ApiFieldType.text,
+            isRequired: true,
+            label: 'Request Body',
+            hint: 'The JSON body of the request with updated fields',
+          ),
+        ],
+      };
+}

--- a/packages/apis/example/lib/services/handlers/smart_collection_handlers/updates_ordering_type_of_products_smart_collection_handler.dart
+++ b/packages/apis/example/lib/services/handlers/smart_collection_handlers/updates_ordering_type_of_products_smart_collection_handler.dart
@@ -1,0 +1,95 @@
+import 'dart:convert';
+
+import 'package:apis/apis.dart';
+import 'package:apis/network/remote/smart_collections/abstract/smart_collection_service.dart';
+import 'package:apis/network/remote/smart_collections/freezed_model/request/updates_ordering_type_of_products_smart_collection_request.dart';
+import 'package:example/services/api_request_handler.dart';
+import 'package:example/services/api_service_registry.dart';
+import 'package:get_it/get_it.dart';
+
+///**************************************************************
+///************ 🔀 UPDATE PRODUCT ORDER HANDLER *****************
+///**************************************************************
+
+class UpdateProductOrderHandler implements ApiRequestHandler {
+  @override
+  Future<Map<String, dynamic>> handleRequest(
+    String method,
+    Map<String, String> params,
+  ) async {
+    if (method != 'PUT') {
+      return {
+        'status': 'error',
+        'message': 'Method $method not supported. Only PUT is allowed.',
+        'timestamp': DateTime.now().toIso8601String(),
+      };
+    }
+
+    final id = params['id'];
+    final rawBody = params['body'];
+
+    if (id == null || id.isEmpty) {
+      return {
+        'status': 'error',
+        'message': 'Missing required parameter: id',
+        'timestamp': DateTime.now().toIso8601String(),
+      };
+    }
+
+    if (rawBody == null || rawBody.isEmpty) {
+      return {
+        'status': 'error',
+        'message': 'Missing request body.',
+        'timestamp': DateTime.now().toIso8601String(),
+      };
+    }
+
+    try {
+      final decodedJson = json.decode(rawBody) as Map<String, dynamic>;
+      final request = UpdateOrderingTypeOfProductsRequest.fromJson(decodedJson);
+
+      final response =
+          await GetIt.I<SmartCollectionService>().updateProductOrder(
+        apiVersion: ApiNetwork.apiVersion,
+        id: id,
+        request: request,
+      );
+
+      return {
+        'status': 'success',
+        'data': response.toJson(), // büyük ihtimalle boş {}
+        'timestamp': DateTime.now().toIso8601String(),
+      };
+    } catch (e) {
+      return {
+        'status': 'error',
+        'message': 'Failed to update product order: ${e.toString()}',
+        'timestamp': DateTime.now().toIso8601String(),
+      };
+    }
+  }
+
+  @override
+  List<String> get supportedMethods => ['PUT'];
+
+  @override
+  Map<String, List<ApiField>> get requiredFields => {
+        'PUT': [
+          ApiField(
+            name: 'id',
+            type: ApiFieldType.text,
+            isRequired: true,
+            label: 'Smart Collection ID',
+            hint:
+                'The ID of the smart collection you want to update product order for',
+          ),
+          ApiField(
+            name: 'body',
+            type: ApiFieldType.text,
+            isRequired: true,
+            label: 'Request Body',
+            hint: 'The JSON body containing sort_order and product IDs',
+          ),
+        ],
+      };
+}

--- a/packages/apis/lib/network/remote/smart_collections/abstract/smart_collection_service.dart
+++ b/packages/apis/lib/network/remote/smart_collections/abstract/smart_collection_service.dart
@@ -5,6 +5,7 @@ import 'package:apis/network/remote/smart_collections/freezed_model/request/upda
 import 'package:apis/network/remote/smart_collections/freezed_model/response/updates_existing_smart_collection_response.dart';
 import 'package:apis/network/remote/smart_collections/freezed_model/request/updates_ordering_type_of_products_smart_collection_request.dart';
 import 'package:apis/network/remote/smart_collections/freezed_model/response/updates_ordering_type_of_products_smart_collection_response.dart';
+import 'package:apis/network/remote/smart_collections/freezed_model/request/create_smart_collection_request.dart';
 
 
 /// 🌐 SmartCollectionService
@@ -47,6 +48,12 @@ abstract class SmartCollectionService {
   Future<void> deleteSmartCollection({
     required String apiVersion,
     required String id,
+  });
+
+  /// 🆕 Creates a new smart collection
+  Future<RetrievesSingleSmartCollectionsResponse> createSmartCollection({
+    required String apiVersion,
+    required CreateSmartCollectionRequest request,
   });
 
  

--- a/packages/apis/lib/network/remote/smart_collections/abstract/smart_collection_service.dart
+++ b/packages/apis/lib/network/remote/smart_collections/abstract/smart_collection_service.dart
@@ -1,6 +1,10 @@
 import 'package:apis/network/remote/smart_collections/freezed_model/response/retrieves_list_of_smart_collections_response.dart';
 import 'package:apis/network/remote/smart_collections/freezed_model/response/retrieves_single_smart_collection_response.dart';
 import 'package:apis/network/remote/smart_collections/freezed_model/response/retrieves_count_of_smart_collections_response.dart';
+import 'package:apis/network/remote/smart_collections/freezed_model/request/updates_existing_smart_collection_request.dart';
+import 'package:apis/network/remote/smart_collections/freezed_model/response/updates_existing_smart_collection_response.dart';
+import 'package:apis/network/remote/smart_collections/freezed_model/request/updates_ordering_type_of_products_smart_collection_request.dart';
+import 'package:apis/network/remote/smart_collections/freezed_model/response/updates_ordering_type_of_products_smart_collection_response.dart';
 
 
 /// 🌐 SmartCollectionService
@@ -24,4 +28,21 @@ abstract class SmartCollectionService {
   Future<RetrievesCountOfSmartCollectionsResponse> countSmartCollections({
     required String apiVersion,
   });
+
+  /// ✏ Updates an existing smart collection
+  Future<UpdatesExistingSmartCollectionResponse> updateSmartCollection({
+    required String apiVersion,
+    required String id,
+    required UpdateSmartCollectionRequest request,
+  });
+
+  /// 🔀 Updates product order of a smart collection
+  Future<UpdatesOrderingTypeOfProductsSmartCollection> updateProductOrder({
+    required String apiVersion,
+    required String id,
+    required UpdateOrderingTypeOfProductsRequest request,
+  });
+
+ 
+
 }

--- a/packages/apis/lib/network/remote/smart_collections/abstract/smart_collection_service.dart
+++ b/packages/apis/lib/network/remote/smart_collections/abstract/smart_collection_service.dart
@@ -43,6 +43,12 @@ abstract class SmartCollectionService {
     required UpdateOrderingTypeOfProductsRequest request,
   });
 
+  /// ❌ Deletes a smart collection by ID
+  Future<void> deleteSmartCollection({
+    required String apiVersion,
+    required String id,
+  });
+
  
 
 }

--- a/packages/apis/lib/network/remote/smart_collections/abstract/smart_collection_service.dart
+++ b/packages/apis/lib/network/remote/smart_collections/abstract/smart_collection_service.dart
@@ -1,5 +1,7 @@
 import 'package:apis/network/remote/smart_collections/freezed_model/response/retrieves_list_of_smart_collections_response.dart';
 import 'package:apis/network/remote/smart_collections/freezed_model/response/retrieves_single_smart_collection_response.dart';
+import 'package:apis/network/remote/smart_collections/freezed_model/response/retrieves_count_of_smart_collections_response.dart';
+
 
 /// 🌐 SmartCollectionService
 abstract class SmartCollectionService {
@@ -16,5 +18,10 @@ abstract class SmartCollectionService {
       retrieveSingleSmartCollection({
     required String apiVersion,
     required String id,
+  });
+
+  /// 🔢 Retrieves count of smart collections
+  Future<RetrievesCountOfSmartCollectionsResponse> countSmartCollections({
+    required String apiVersion,
   });
 }

--- a/packages/apis/lib/network/remote/smart_collections/abstract/smart_collection_service.dart
+++ b/packages/apis/lib/network/remote/smart_collections/abstract/smart_collection_service.dart
@@ -1,12 +1,11 @@
+import 'package:apis/network/remote/smart_collections/freezed_model/request/create_smart_collection_request.dart';
+import 'package:apis/network/remote/smart_collections/freezed_model/request/updates_existing_smart_collection_request.dart';
+import 'package:apis/network/remote/smart_collections/freezed_model/request/updates_ordering_type_of_products_smart_collection_request.dart';
 import 'package:apis/network/remote/smart_collections/freezed_model/response/retrieves_list_of_smart_collections_response.dart';
 import 'package:apis/network/remote/smart_collections/freezed_model/response/retrieves_single_smart_collection_response.dart';
 import 'package:apis/network/remote/smart_collections/freezed_model/response/retrieves_count_of_smart_collections_response.dart';
-import 'package:apis/network/remote/smart_collections/freezed_model/request/updates_existing_smart_collection_request.dart';
 import 'package:apis/network/remote/smart_collections/freezed_model/response/updates_existing_smart_collection_response.dart';
-import 'package:apis/network/remote/smart_collections/freezed_model/request/updates_ordering_type_of_products_smart_collection_request.dart';
 import 'package:apis/network/remote/smart_collections/freezed_model/response/updates_ordering_type_of_products_smart_collection_response.dart';
-import 'package:apis/network/remote/smart_collections/freezed_model/request/create_smart_collection_request.dart';
-
 
 /// 🌐 SmartCollectionService
 abstract class SmartCollectionService {
@@ -16,18 +15,47 @@ abstract class SmartCollectionService {
     int? limit,
     String? sinceId,
     String? fields,
+    String? ids,
+    String? title,
+    String? handle,
+    String? productId,
+    String? updatedAtMin,
+    String? updatedAtMax,
+    String? publishedAtMin,
+    String? publishedAtMax,
+    String? publishedStatus,
   });
 
-  /// 📥 Retrieves a single smart collection by ID
+  /// 📄 Retrieves a single smart collection by ID
   Future<RetrievesSingleSmartCollectionsResponse>
       retrieveSingleSmartCollection({
     required String apiVersion,
     required String id,
+    String? fields,
   });
 
   /// 🔢 Retrieves count of smart collections
   Future<RetrievesCountOfSmartCollectionsResponse> countSmartCollections({
     required String apiVersion,
+    String? title,
+    String? productId,
+    String? updatedAtMin,
+    String? updatedAtMax,
+    String? publishedAtMin,
+    String? publishedAtMax,
+    String? publishedStatus,
+  });
+
+  /// 🆕 Creates a new smart collection
+  Future<RetrievesSingleSmartCollectionsResponse> createSmartCollection({
+    required String apiVersion,
+    required CreateSmartCollectionRequest request,
+  });
+
+  /// ❌ Deletes a smart collection by ID
+  Future<void> deleteSmartCollection({
+    required String apiVersion,
+    required String id,
   });
 
   /// ✏ Updates an existing smart collection
@@ -43,19 +71,4 @@ abstract class SmartCollectionService {
     required String id,
     required UpdateOrderingTypeOfProductsRequest request,
   });
-
-  /// ❌ Deletes a smart collection by ID
-  Future<void> deleteSmartCollection({
-    required String apiVersion,
-    required String id,
-  });
-
-  /// 🆕 Creates a new smart collection
-  Future<RetrievesSingleSmartCollectionsResponse> createSmartCollection({
-    required String apiVersion,
-    required CreateSmartCollectionRequest request,
-  });
-
- 
-
 }

--- a/packages/apis/lib/network/remote/smart_collections/abstract/smart_collection_service.dart
+++ b/packages/apis/lib/network/remote/smart_collections/abstract/smart_collection_service.dart
@@ -1,0 +1,12 @@
+import 'package:apis/network/remote/smart_collections/freezed_model/response/retrieves_list_of_smart_collections_response.dart';
+
+/// 🌐 SmartCollectionService
+abstract class SmartCollectionService {
+  /// 📥 Retrieves all smart collections
+  Future<RetrievesListOfSmartCollectionsResponse> listSmartCollections({
+    required String apiVersion,
+    int? limit,
+    String? sinceId,
+    String? fields,
+  });
+}

--- a/packages/apis/lib/network/remote/smart_collections/abstract/smart_collection_service.dart
+++ b/packages/apis/lib/network/remote/smart_collections/abstract/smart_collection_service.dart
@@ -1,4 +1,5 @@
 import 'package:apis/network/remote/smart_collections/freezed_model/response/retrieves_list_of_smart_collections_response.dart';
+import 'package:apis/network/remote/smart_collections/freezed_model/response/retrieves_single_smart_collection_response.dart';
 
 /// 🌐 SmartCollectionService
 abstract class SmartCollectionService {
@@ -8,5 +9,12 @@ abstract class SmartCollectionService {
     int? limit,
     String? sinceId,
     String? fields,
+  });
+
+  /// 📥 Retrieves a single smart collection by ID
+  Future<RetrievesSingleSmartCollectionsResponse>
+      retrieveSingleSmartCollection({
+    required String apiVersion,
+    required String id,
   });
 }

--- a/packages/apis/lib/network/remote/smart_collections/api/api_smart_collection_service.dart
+++ b/packages/apis/lib/network/remote/smart_collections/api/api_smart_collection_service.dart
@@ -8,6 +8,8 @@ import 'package:apis/network/remote/smart_collections/freezed_model/request/upda
 import 'package:apis/network/remote/smart_collections/freezed_model/response/updates_existing_smart_collection_response.dart';
 import 'package:apis/network/remote/smart_collections/freezed_model/request/updates_ordering_type_of_products_smart_collection_request.dart';
 import 'package:apis/network/remote/smart_collections/freezed_model/response/updates_ordering_type_of_products_smart_collection_response.dart';
+import 'package:apis/network/remote/smart_collections/freezed_model/request/create_smart_collection_request.dart';
+
 
 
 
@@ -78,6 +80,14 @@ abstract class ApiSmartCollectionService implements SmartCollectionService {
   Future<void> deleteSmartCollection({
     @Path('api_version') required String apiVersion,
     @Path('id') required String id,
+  });
+
+  /// 🆕 Creates a new smart collection
+  @POST('/api/{api_version}/smart_collections.json')
+  @override
+  Future<RetrievesSingleSmartCollectionsResponse> createSmartCollection({
+    @Path('api_version') required String apiVersion,
+    @Body() required CreateSmartCollectionRequest request,
   });
 
 

--- a/packages/apis/lib/network/remote/smart_collections/api/api_smart_collection_service.dart
+++ b/packages/apis/lib/network/remote/smart_collections/api/api_smart_collection_service.dart
@@ -1,18 +1,14 @@
 import 'package:apis/apis.dart';
 import 'package:apis/dio_config/api_dio_client.dart';
 import 'package:apis/network/remote/smart_collections/abstract/smart_collection_service.dart';
+import 'package:apis/network/remote/smart_collections/freezed_model/request/create_smart_collection_request.dart';
+import 'package:apis/network/remote/smart_collections/freezed_model/request/updates_existing_smart_collection_request.dart';
+import 'package:apis/network/remote/smart_collections/freezed_model/request/updates_ordering_type_of_products_smart_collection_request.dart';
 import 'package:apis/network/remote/smart_collections/freezed_model/response/retrieves_list_of_smart_collections_response.dart';
 import 'package:apis/network/remote/smart_collections/freezed_model/response/retrieves_single_smart_collection_response.dart';
 import 'package:apis/network/remote/smart_collections/freezed_model/response/retrieves_count_of_smart_collections_response.dart';
-import 'package:apis/network/remote/smart_collections/freezed_model/request/updates_existing_smart_collection_request.dart';
 import 'package:apis/network/remote/smart_collections/freezed_model/response/updates_existing_smart_collection_response.dart';
-import 'package:apis/network/remote/smart_collections/freezed_model/request/updates_ordering_type_of_products_smart_collection_request.dart';
 import 'package:apis/network/remote/smart_collections/freezed_model/response/updates_ordering_type_of_products_smart_collection_response.dart';
-import 'package:apis/network/remote/smart_collections/freezed_model/request/create_smart_collection_request.dart';
-
-
-
-
 import 'package:dio/dio.dart';
 import 'package:injectable/injectable.dart';
 import 'package:retrofit/http.dart';
@@ -21,7 +17,6 @@ part 'api_smart_collection_service.g.dart';
 
 @RestApi()
 @Injectable(as: SmartCollectionService)
-
 abstract class ApiSmartCollectionService implements SmartCollectionService {
   /// 🏭 Factory for dependency injection
   @factoryMethod
@@ -38,15 +33,25 @@ abstract class ApiSmartCollectionService implements SmartCollectionService {
     @Query('limit') int? limit,
     @Query('since_id') String? sinceId,
     @Query('fields') String? fields,
+    @Query('ids') String? ids,
+    @Query('title') String? title,
+    @Query('handle') String? handle,
+    @Query('product_id') String? productId,
+    @Query('updated_at_min') String? updatedAtMin,
+    @Query('updated_at_max') String? updatedAtMax,
+    @Query('published_at_min') String? publishedAtMin,
+    @Query('published_at_max') String? publishedAtMax,
+    @Query('published_status') String? publishedStatus,
   });
 
-  /// 📥 Retrieves a single smart collection by ID
+  /// 📄 Retrieves a single smart collection by ID
   @GET('/api/{api_version}/smart_collections/{id}.json')
   @override
   Future<RetrievesSingleSmartCollectionsResponse>
       retrieveSingleSmartCollection({
     @Path('api_version') required String apiVersion,
     @Path('id') required String id,
+    @Query('fields') String? fields, // 👈 query olarak gönderilir
   });
 
   /// 🔢 Retrieves count of smart collections
@@ -54,6 +59,29 @@ abstract class ApiSmartCollectionService implements SmartCollectionService {
   @override
   Future<RetrievesCountOfSmartCollectionsResponse> countSmartCollections({
     @Path('api_version') required String apiVersion,
+    @Query('title') String? title,
+    @Query('product_id') String? productId,
+    @Query('updated_at_min') String? updatedAtMin,
+    @Query('updated_at_max') String? updatedAtMax,
+    @Query('published_at_min') String? publishedAtMin,
+    @Query('published_at_max') String? publishedAtMax,
+    @Query('published_status') String? publishedStatus,
+  });
+
+  /// 🆕 Creates a new smart collection
+  @POST('/api/{api_version}/smart_collections.json')
+  @override
+  Future<RetrievesSingleSmartCollectionsResponse> createSmartCollection({
+    @Path('api_version') required String apiVersion,
+    @Body() required CreateSmartCollectionRequest request,
+  });
+
+  /// ❌ Deletes a smart collection by ID
+  @override
+  @DELETE('/api/{api_version}/smart_collections/{id}.json')
+  Future<void> deleteSmartCollection({
+    @Path('api_version') required String apiVersion,
+    @Path('id') required String id,
   });
 
   /// ✏ Updates an existing smart collection
@@ -73,26 +101,4 @@ abstract class ApiSmartCollectionService implements SmartCollectionService {
     @Path('id') required String id,
     @Body() required UpdateOrderingTypeOfProductsRequest request,
   });
-
-  /// ❌ Deletes a smart collection by ID
-  @override
-  @DELETE('/api/{api_version}/smart_collections/{id}.json')
-  Future<void> deleteSmartCollection({
-    @Path('api_version') required String apiVersion,
-    @Path('id') required String id,
-  });
-
-  /// 🆕 Creates a new smart collection
-  @POST('/api/{api_version}/smart_collections.json')
-  @override
-  Future<RetrievesSingleSmartCollectionsResponse> createSmartCollection({
-    @Path('api_version') required String apiVersion,
-    @Body() required CreateSmartCollectionRequest request,
-  });
-
-
-  
-
-
-
 }

--- a/packages/apis/lib/network/remote/smart_collections/api/api_smart_collection_service.dart
+++ b/packages/apis/lib/network/remote/smart_collections/api/api_smart_collection_service.dart
@@ -4,6 +4,12 @@ import 'package:apis/network/remote/smart_collections/abstract/smart_collection_
 import 'package:apis/network/remote/smart_collections/freezed_model/response/retrieves_list_of_smart_collections_response.dart';
 import 'package:apis/network/remote/smart_collections/freezed_model/response/retrieves_single_smart_collection_response.dart';
 import 'package:apis/network/remote/smart_collections/freezed_model/response/retrieves_count_of_smart_collections_response.dart';
+import 'package:apis/network/remote/smart_collections/freezed_model/request/updates_existing_smart_collection_request.dart';
+import 'package:apis/network/remote/smart_collections/freezed_model/response/updates_existing_smart_collection_response.dart';
+import 'package:apis/network/remote/smart_collections/freezed_model/request/updates_ordering_type_of_products_smart_collection_request.dart';
+import 'package:apis/network/remote/smart_collections/freezed_model/response/updates_ordering_type_of_products_smart_collection_response.dart';
+
+
 
 import 'package:dio/dio.dart';
 import 'package:injectable/injectable.dart';
@@ -46,6 +52,24 @@ abstract class ApiSmartCollectionService implements SmartCollectionService {
   @override
   Future<RetrievesCountOfSmartCollectionsResponse> countSmartCollections({
     @Path('api_version') required String apiVersion,
+  });
+
+  /// ✏ Updates an existing smart collection
+  @PUT('/api/{api_version}/smart_collections/{id}.json')
+  @override
+  Future<UpdatesExistingSmartCollectionResponse> updateSmartCollection({
+    @Path('api_version') required String apiVersion,
+    @Path('id') required String id,
+    @Body() required UpdateSmartCollectionRequest request,
+  });
+
+  /// 🔀 Updates ordering of products in a smart collection (manual sort)
+  @PUT('/api/{api_version}/smart_collections/{id}/order.json')
+  @override
+  Future<UpdatesOrderingTypeOfProductsSmartCollection> updateProductOrder({
+    @Path('api_version') required String apiVersion,
+    @Path('id') required String id,
+    @Body() required UpdateOrderingTypeOfProductsRequest request,
   });
 
   

--- a/packages/apis/lib/network/remote/smart_collections/api/api_smart_collection_service.dart
+++ b/packages/apis/lib/network/remote/smart_collections/api/api_smart_collection_service.dart
@@ -2,6 +2,7 @@ import 'package:apis/apis.dart';
 import 'package:apis/dio_config/api_dio_client.dart';
 import 'package:apis/network/remote/smart_collections/abstract/smart_collection_service.dart';
 import 'package:apis/network/remote/smart_collections/freezed_model/response/retrieves_list_of_smart_collections_response.dart';
+import 'package:apis/network/remote/smart_collections/freezed_model/response/retrieves_single_smart_collection_response.dart';
 import 'package:dio/dio.dart';
 import 'package:injectable/injectable.dart';
 import 'package:retrofit/http.dart';
@@ -27,6 +28,15 @@ abstract class ApiSmartCollectionService implements SmartCollectionService {
     @Query('limit') int? limit,
     @Query('since_id') String? sinceId,
     @Query('fields') String? fields,
+  });
+
+  /// 📥 Retrieves a single smart collection by ID
+  @GET('/api/{api_version}/smart_collections/{id}.json')
+  @override
+  Future<RetrievesSingleSmartCollectionsResponse>
+      retrieveSingleSmartCollection({
+    @Path('api_version') required String apiVersion,
+    @Path('id') required String id,
   });
 
 

--- a/packages/apis/lib/network/remote/smart_collections/api/api_smart_collection_service.dart
+++ b/packages/apis/lib/network/remote/smart_collections/api/api_smart_collection_service.dart
@@ -72,6 +72,15 @@ abstract class ApiSmartCollectionService implements SmartCollectionService {
     @Body() required UpdateOrderingTypeOfProductsRequest request,
   });
 
+  /// ❌ Deletes a smart collection by ID
+  @override
+  @DELETE('/api/{api_version}/smart_collections/{id}.json')
+  Future<void> deleteSmartCollection({
+    @Path('api_version') required String apiVersion,
+    @Path('id') required String id,
+  });
+
+
   
 
 

--- a/packages/apis/lib/network/remote/smart_collections/api/api_smart_collection_service.dart
+++ b/packages/apis/lib/network/remote/smart_collections/api/api_smart_collection_service.dart
@@ -1,0 +1,33 @@
+import 'package:apis/apis.dart';
+import 'package:apis/dio_config/api_dio_client.dart';
+import 'package:apis/network/remote/smart_collections/abstract/smart_collection_service.dart';
+import 'package:apis/network/remote/smart_collections/freezed_model/response/retrieves_list_of_smart_collections_response.dart';
+import 'package:dio/dio.dart';
+import 'package:injectable/injectable.dart';
+import 'package:retrofit/http.dart';
+
+part 'api_smart_collection_service.g.dart';
+
+@RestApi()
+@Injectable(as: SmartCollectionService)
+
+abstract class ApiSmartCollectionService implements SmartCollectionService {
+  /// 🏭 Factory for dependency injection
+  @factoryMethod
+  factory ApiSmartCollectionService(Dio dio) => _ApiSmartCollectionService(
+        ApiDioClient.starter(),
+        baseUrl: ApiNetwork.baseUrl,
+      );
+
+  /// 📥 Retrieves all smart collections
+  @GET('/api/{api_version}/smart_collections.json')
+  @override
+  Future<RetrievesListOfSmartCollectionsResponse> listSmartCollections({
+    @Path('api_version') required String apiVersion,
+    @Query('limit') int? limit,
+    @Query('since_id') String? sinceId,
+    @Query('fields') String? fields,
+  });
+
+
+}

--- a/packages/apis/lib/network/remote/smart_collections/api/api_smart_collection_service.dart
+++ b/packages/apis/lib/network/remote/smart_collections/api/api_smart_collection_service.dart
@@ -3,6 +3,8 @@ import 'package:apis/dio_config/api_dio_client.dart';
 import 'package:apis/network/remote/smart_collections/abstract/smart_collection_service.dart';
 import 'package:apis/network/remote/smart_collections/freezed_model/response/retrieves_list_of_smart_collections_response.dart';
 import 'package:apis/network/remote/smart_collections/freezed_model/response/retrieves_single_smart_collection_response.dart';
+import 'package:apis/network/remote/smart_collections/freezed_model/response/retrieves_count_of_smart_collections_response.dart';
+
 import 'package:dio/dio.dart';
 import 'package:injectable/injectable.dart';
 import 'package:retrofit/http.dart';
@@ -38,6 +40,16 @@ abstract class ApiSmartCollectionService implements SmartCollectionService {
     @Path('api_version') required String apiVersion,
     @Path('id') required String id,
   });
+
+  /// 🔢 Retrieves count of smart collections
+  @GET('/api/{api_version}/smart_collections/count.json')
+  @override
+  Future<RetrievesCountOfSmartCollectionsResponse> countSmartCollections({
+    @Path('api_version') required String apiVersion,
+  });
+
+  
+
 
 
 }

--- a/packages/apis/lib/network/remote/smart_collections/freezed_model/request/create_smart_collection_request.dart
+++ b/packages/apis/lib/network/remote/smart_collections/freezed_model/request/create_smart_collection_request.dart
@@ -1,0 +1,57 @@
+// To parse this JSON data, do
+//
+//     final createSmartCollectionRequest = createSmartCollectionRequestFromJson(jsonString);
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'dart:convert';
+
+part 'create_smart_collection_request.freezed.dart';
+part 'create_smart_collection_request.g.dart';
+
+CreateSmartCollectionRequest createSmartCollectionRequestFromJson(String str) =>
+    CreateSmartCollectionRequest.fromJson(json.decode(str));
+
+String createSmartCollectionRequestToJson(CreateSmartCollectionRequest data) =>
+    json.encode(data.toJson());
+
+@freezed
+class CreateSmartCollectionRequest with _$CreateSmartCollectionRequest {
+  const factory CreateSmartCollectionRequest({
+    @JsonKey(name: "smart_collection") SmartCollection? smartCollection,
+  }) = _CreateSmartCollectionRequest;
+
+  factory CreateSmartCollectionRequest.fromJson(Map<String, dynamic> json) =>
+      _$CreateSmartCollectionRequestFromJson(json);
+}
+
+@freezed
+class SmartCollection with _$SmartCollection {
+  const factory SmartCollection({
+    @JsonKey(name: "id") int? id,
+    @JsonKey(name: "handle") String? handle,
+    @JsonKey(name: "title") String? title,
+    @JsonKey(name: "updated_at") String? updatedAt,
+    @JsonKey(name: "body_html") dynamic bodyHtml,
+    @JsonKey(name: "published_at") String? publishedAt,
+    @JsonKey(name: "sort_order") String? sortOrder,
+    @JsonKey(name: "template_suffix") dynamic templateSuffix,
+    @JsonKey(name: "disjunctive") bool? disjunctive,
+    @JsonKey(name: "rules") List<Rule>? rules,
+    @JsonKey(name: "published_scope") String? publishedScope,
+    @JsonKey(name: "admin_graphql_api_id") String? adminGraphqlApiId,
+  }) = _SmartCollection;
+
+  factory SmartCollection.fromJson(Map<String, dynamic> json) =>
+      _$SmartCollectionFromJson(json);
+}
+
+@freezed
+class Rule with _$Rule {
+  const factory Rule({
+    @JsonKey(name: "column") String? column,
+    @JsonKey(name: "relation") String? relation,
+    @JsonKey(name: "condition") String? condition,
+  }) = _Rule;
+
+  factory Rule.fromJson(Map<String, dynamic> json) => _$RuleFromJson(json);
+}

--- a/packages/apis/lib/network/remote/smart_collections/freezed_model/request/updates_existing_smart_collection_request.dart
+++ b/packages/apis/lib/network/remote/smart_collections/freezed_model/request/updates_existing_smart_collection_request.dart
@@ -1,0 +1,46 @@
+// To create this request:
+// final updateSmartCollectionRequest = UpdateSmartCollectionRequest(...);
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'updates_existing_smart_collection_request.freezed.dart';
+part 'updates_existing_smart_collection_request.g.dart';
+
+@freezed
+class UpdateSmartCollectionRequest with _$UpdateSmartCollectionRequest {
+  const factory UpdateSmartCollectionRequest({
+    @JsonKey(name: "smart_collection") SmartCollection? smartCollection,
+  }) = _UpdateSmartCollectionRequest;
+
+  factory UpdateSmartCollectionRequest.fromJson(Map<String, dynamic> json) =>
+      _$UpdateSmartCollectionRequestFromJson(json);
+}
+
+@freezed
+class SmartCollection with _$SmartCollection {
+  const factory SmartCollection({
+    @JsonKey(name: "id") int? id,
+    @JsonKey(name: "title") String? title,
+    @JsonKey(name: "body_html") String? bodyHtml,
+    @JsonKey(name: "sort_order") String? sortOrder,
+    @JsonKey(name: "disjunctive") bool? disjunctive,
+    @JsonKey(name: "template_suffix") dynamic templateSuffix,
+    @JsonKey(name: "handle") String? handle,
+    @JsonKey(name: "rules") List<Rule>? rules,
+    @JsonKey(name: "published_scope") String? publishedScope,
+  }) = _SmartCollection;
+
+  factory SmartCollection.fromJson(Map<String, dynamic> json) =>
+      _$SmartCollectionFromJson(json);
+}
+
+@freezed
+class Rule with _$Rule {
+  const factory Rule({
+    @JsonKey(name: "column") String? column,
+    @JsonKey(name: "relation") String? relation,
+    @JsonKey(name: "condition") String? condition,
+  }) = _Rule;
+
+  factory Rule.fromJson(Map<String, dynamic> json) => _$RuleFromJson(json);
+}

--- a/packages/apis/lib/network/remote/smart_collections/freezed_model/request/updates_ordering_type_of_products_smart_collection_request.dart
+++ b/packages/apis/lib/network/remote/smart_collections/freezed_model/request/updates_ordering_type_of_products_smart_collection_request.dart
@@ -1,0 +1,17 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'updates_ordering_type_of_products_smart_collection_request.freezed.dart';
+part 'updates_ordering_type_of_products_smart_collection_request.g.dart';
+
+@freezed
+class UpdateOrderingTypeOfProductsRequest
+    with _$UpdateOrderingTypeOfProductsRequest {
+  const factory UpdateOrderingTypeOfProductsRequest({
+    @JsonKey(name: 'sort_order') required String sortOrder,
+    @JsonKey(name: 'products') required List<int> products,
+  }) = _UpdateOrderingTypeOfProductsRequest;
+
+  factory UpdateOrderingTypeOfProductsRequest.fromJson(
+          Map<String, dynamic> json) =>
+      _$UpdateOrderingTypeOfProductsRequestFromJson(json);
+}

--- a/packages/apis/lib/network/remote/smart_collections/freezed_model/response/retrieves_count_of_smart_collections_response.dart
+++ b/packages/apis/lib/network/remote/smart_collections/freezed_model/response/retrieves_count_of_smart_collections_response.dart
@@ -1,0 +1,29 @@
+// To parse this JSON data, do
+//
+//     final retrievesCountOfSmartCollectionsResponse = retrievesCountOfSmartCollectionsResponseFromJson(jsonString);
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'dart:convert';
+
+part 'retrieves_count_of_smart_collections_response.freezed.dart';
+part 'retrieves_count_of_smart_collections_response.g.dart';
+
+RetrievesCountOfSmartCollectionsResponse
+    retrievesCountOfSmartCollectionsResponseFromJson(String str) =>
+        RetrievesCountOfSmartCollectionsResponse.fromJson(json.decode(str));
+
+String retrievesCountOfSmartCollectionsResponseToJson(
+        RetrievesCountOfSmartCollectionsResponse data) =>
+    json.encode(data.toJson());
+
+@freezed
+class RetrievesCountOfSmartCollectionsResponse
+    with _$RetrievesCountOfSmartCollectionsResponse {
+  const factory RetrievesCountOfSmartCollectionsResponse({
+    @JsonKey(name: "count") int? count,
+  }) = _RetrievesCountOfSmartCollectionsResponse;
+
+  factory RetrievesCountOfSmartCollectionsResponse.fromJson(
+          Map<String, dynamic> json) =>
+      _$RetrievesCountOfSmartCollectionsResponseFromJson(json);
+}

--- a/packages/apis/lib/network/remote/smart_collections/freezed_model/response/retrieves_list_of_smart_collections_response.dart
+++ b/packages/apis/lib/network/remote/smart_collections/freezed_model/response/retrieves_list_of_smart_collections_response.dart
@@ -1,0 +1,89 @@
+// To parse this JSON data, do
+//
+//     final retrievesListOfSmartCollectionsResponse = retrievesListOfSmartCollectionsResponseFromJson(jsonString);
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'dart:convert';
+
+part 'retrieves_list_of_smart_collections_response.freezed.dart';
+part 'retrieves_list_of_smart_collections_response.g.dart';
+
+RetrievesListOfSmartCollectionsResponse retrievesListOfSmartCollectionsResponseFromJson(String str) => RetrievesListOfSmartCollectionsResponse.fromJson(json.decode(str));
+
+String retrievesListOfSmartCollectionsResponseToJson(RetrievesListOfSmartCollectionsResponse data) => json.encode(data.toJson());
+
+@freezed
+class RetrievesListOfSmartCollectionsResponse with _$RetrievesListOfSmartCollectionsResponse {
+    const factory RetrievesListOfSmartCollectionsResponse({
+        @JsonKey(name: "smart_collections")
+        List<SmartCollection>? smartCollections,
+    }) = _RetrievesListOfSmartCollectionsResponse;
+
+    factory RetrievesListOfSmartCollectionsResponse.fromJson(Map<String, dynamic> json) => _$RetrievesListOfSmartCollectionsResponseFromJson(json);
+}
+
+@freezed
+class SmartCollection with _$SmartCollection {
+    const factory SmartCollection({
+        @JsonKey(name: "id")
+        int? id,
+        @JsonKey(name: "handle")
+        String? handle,
+        @JsonKey(name: "title")
+        String? title,
+        @JsonKey(name: "updated_at")
+        String? updatedAt,
+        @JsonKey(name: "body_html")
+        dynamic bodyHtml,
+        @JsonKey(name: "published_at")
+        String? publishedAt,
+        @JsonKey(name: "sort_order")
+        String? sortOrder,
+        @JsonKey(name: "template_suffix")
+        dynamic templateSuffix,
+        @JsonKey(name: "disjunctive")
+        bool? disjunctive,
+        @JsonKey(name: "rules")
+        List<Rule>? rules,
+        @JsonKey(name: "published_scope")
+        String? publishedScope,
+        @JsonKey(name: "admin_graphql_api_id")
+        String? adminGraphqlApiId,
+        @JsonKey(name: "image")
+        Image? image,
+    }) = _SmartCollection;
+
+    factory SmartCollection.fromJson(Map<String, dynamic> json) => _$SmartCollectionFromJson(json);
+}
+
+@freezed
+class Image with _$Image {
+    const factory Image({
+        @JsonKey(name: "created_at")
+        String? createdAt,
+        @JsonKey(name: "alt")
+        String? alt,
+        @JsonKey(name: "width")
+        int? width,
+        @JsonKey(name: "height")
+        int? height,
+        @JsonKey(name: "src")
+        String? src,
+    }) = _Image;
+
+    factory Image.fromJson(Map<String, dynamic> json) => _$ImageFromJson(json);
+}
+
+@freezed
+class Rule with _$Rule {
+    const factory Rule({
+        @JsonKey(name: "column")
+        String? column,
+        @JsonKey(name: "relation")
+        String? relation,
+        @JsonKey(name: "condition")
+        String? condition,
+    }) = _Rule;
+
+    factory Rule.fromJson(Map<String, dynamic> json) => _$RuleFromJson(json);
+}

--- a/packages/apis/lib/network/remote/smart_collections/freezed_model/response/retrieves_single_smart_collection_response.dart
+++ b/packages/apis/lib/network/remote/smart_collections/freezed_model/response/retrieves_single_smart_collection_response.dart
@@ -1,0 +1,62 @@
+// To parse this JSON data, do
+//
+//     final retrievesSingleSmartCollectionsResponse = retrievesSingleSmartCollectionsResponseFromJson(jsonString);
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'dart:convert';
+
+part 'retrieves_single_smart_collection_response.freezed.dart';
+part 'retrieves_single_smart_collection_response.g.dart';
+
+RetrievesSingleSmartCollectionsResponse
+    retrievesSingleSmartCollectionsResponseFromJson(String str) =>
+        RetrievesSingleSmartCollectionsResponse.fromJson(json.decode(str));
+
+String retrievesSingleSmartCollectionsResponseToJson(
+        RetrievesSingleSmartCollectionsResponse data) =>
+    json.encode(data.toJson());
+
+@freezed
+class RetrievesSingleSmartCollectionsResponse
+    with _$RetrievesSingleSmartCollectionsResponse {
+  const factory RetrievesSingleSmartCollectionsResponse({
+    @JsonKey(name: "smart_collection") SmartCollection? smartCollection,
+  }) = _RetrievesSingleSmartCollectionsResponse;
+
+  factory RetrievesSingleSmartCollectionsResponse.fromJson(
+          Map<String, dynamic> json) =>
+      _$RetrievesSingleSmartCollectionsResponseFromJson(json);
+}
+
+@freezed
+class SmartCollection with _$SmartCollection {
+  const factory SmartCollection({
+    @JsonKey(name: "id") int? id,
+    @JsonKey(name: "handle") String? handle,
+    @JsonKey(name: "title") String? title,
+    @JsonKey(name: "updated_at") String? updatedAt,
+    @JsonKey(name: "body_html") dynamic bodyHtml,
+    @JsonKey(name: "published_at") String? publishedAt,
+    @JsonKey(name: "sort_order") String? sortOrder,
+    @JsonKey(name: "template_suffix") dynamic templateSuffix,
+    @JsonKey(name: "products_count") int? productsCount,
+    @JsonKey(name: "disjunctive") bool? disjunctive,
+    @JsonKey(name: "rules") List<Rule>? rules,
+    @JsonKey(name: "published_scope") String? publishedScope,
+    @JsonKey(name: "admin_graphql_api_id") String? adminGraphqlApiId,
+  }) = _SmartCollection;
+
+  factory SmartCollection.fromJson(Map<String, dynamic> json) =>
+      _$SmartCollectionFromJson(json);
+}
+
+@freezed
+class Rule with _$Rule {
+  const factory Rule({
+    @JsonKey(name: "column") String? column,
+    @JsonKey(name: "relation") String? relation,
+    @JsonKey(name: "condition") String? condition,
+  }) = _Rule;
+
+  factory Rule.fromJson(Map<String, dynamic> json) => _$RuleFromJson(json);
+}

--- a/packages/apis/lib/network/remote/smart_collections/freezed_model/response/updates_existing_smart_collection_response.dart
+++ b/packages/apis/lib/network/remote/smart_collections/freezed_model/response/updates_existing_smart_collection_response.dart
@@ -1,0 +1,61 @@
+// To parse this JSON data, do
+//
+//     final updatesExistingSmartCollectionResponse = updatesExistingSmartCollectionResponseFromJson(jsonString);
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'dart:convert';
+
+part 'updates_existing_smart_collection_response.freezed.dart';
+part 'updates_existing_smart_collection_response.g.dart';
+
+UpdatesExistingSmartCollectionResponse
+    updatesExistingSmartCollectionResponseFromJson(String str) =>
+        UpdatesExistingSmartCollectionResponse.fromJson(json.decode(str));
+
+String updatesExistingSmartCollectionResponseToJson(
+        UpdatesExistingSmartCollectionResponse data) =>
+    json.encode(data.toJson());
+
+@freezed
+class UpdatesExistingSmartCollectionResponse
+    with _$UpdatesExistingSmartCollectionResponse {
+  const factory UpdatesExistingSmartCollectionResponse({
+    @JsonKey(name: "smart_collection") SmartCollection? smartCollection,
+  }) = _UpdatesExistingSmartCollectionResponse;
+
+  factory UpdatesExistingSmartCollectionResponse.fromJson(
+          Map<String, dynamic> json) =>
+      _$UpdatesExistingSmartCollectionResponseFromJson(json);
+}
+
+@freezed
+class SmartCollection with _$SmartCollection {
+  const factory SmartCollection({
+    @JsonKey(name: "body_html") String? bodyHtml,
+    @JsonKey(name: "sort_order") String? sortOrder,
+    @JsonKey(name: "title") String? title,
+    @JsonKey(name: "disjunctive") bool? disjunctive,
+    @JsonKey(name: "template_suffix") dynamic templateSuffix,
+    @JsonKey(name: "handle") String? handle,
+    @JsonKey(name: "id") int? id,
+    @JsonKey(name: "updated_at") String? updatedAt,
+    @JsonKey(name: "published_at") String? publishedAt,
+    @JsonKey(name: "rules") List<Rule>? rules,
+    @JsonKey(name: "published_scope") String? publishedScope,
+    @JsonKey(name: "admin_graphql_api_id") String? adminGraphqlApiId,
+  }) = _SmartCollection;
+
+  factory SmartCollection.fromJson(Map<String, dynamic> json) =>
+      _$SmartCollectionFromJson(json);
+}
+
+@freezed
+class Rule with _$Rule {
+  const factory Rule({
+    @JsonKey(name: "column") String? column,
+    @JsonKey(name: "relation") String? relation,
+    @JsonKey(name: "condition") String? condition,
+  }) = _Rule;
+
+  factory Rule.fromJson(Map<String, dynamic> json) => _$RuleFromJson(json);
+}

--- a/packages/apis/lib/network/remote/smart_collections/freezed_model/response/updates_ordering_type_of_products_smart_collection_response.dart
+++ b/packages/apis/lib/network/remote/smart_collections/freezed_model/response/updates_ordering_type_of_products_smart_collection_response.dart
@@ -1,0 +1,28 @@
+// To parse this JSON data, do
+//
+//     final updatesOrderingTypeOfProductsSmartCollection = updatesOrderingTypeOfProductsSmartCollectionFromJson(jsonString);
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'dart:convert';
+
+part 'updates_ordering_type_of_products_smart_collection_response.freezed.dart';
+part 'updates_ordering_type_of_products_smart_collection_response.g.dart';
+
+UpdatesOrderingTypeOfProductsSmartCollection
+    updatesOrderingTypeOfProductsSmartCollectionFromJson(String str) =>
+        UpdatesOrderingTypeOfProductsSmartCollection.fromJson(json.decode(str));
+
+String updatesOrderingTypeOfProductsSmartCollectionToJson(
+        UpdatesOrderingTypeOfProductsSmartCollection data) =>
+    json.encode(data.toJson());
+
+@freezed
+class UpdatesOrderingTypeOfProductsSmartCollection
+    with _$UpdatesOrderingTypeOfProductsSmartCollection {
+  const factory UpdatesOrderingTypeOfProductsSmartCollection() =
+      _UpdatesOrderingTypeOfProductsSmartCollection;
+
+  factory UpdatesOrderingTypeOfProductsSmartCollection.fromJson(
+          Map<String, dynamic> json) =>
+      _$UpdatesOrderingTypeOfProductsSmartCollectionFromJson(json);
+}


### PR DESCRIPTION
📋 PR Description

This PR introduces a full-featured implementation of Shopify Smart Collection APIs. It covers all CRUD operations and adds full support for filtering, ordering, and selective field responses. The structure is modular, scalable, and integrates tightly with GetIt, Retrofit, and Freezed, ensuring type-safety and extensibility across the board.

✅ Key Features
	•	📦 List, Retrieve, Create, Update, Delete Smart Collections
	•	🔢 Count smart collections with advanced filters
	•	🧠 Add product ordering updates via /order.json endpoint
	•	🧩 Freezed models for all request/response types
	•	🧪 Field-level filtering with fields, since_id, title, and more
	•	♻ Modular handlers implementing ApiRequestHandler
	•	💉 Fully injectable services using GetIt and Injectable

🔍 Smart Collection APIs Implemented

📥 List Smart Collections
	•	Support for query parameters: limit, since_id, fields, ids, title, handle, product_id, published_status, updated_at_min/max, published_at_min/max
	•	Integrated via listSmartCollections()

📄 Retrieve Single Smart Collection
	•	GET with optional fields param
	•	/smart_collections/{id}.json

🔢 Count Smart Collections
	•	/smart_collections/count.json
	•	Query support for title, product_id, published_status, updated_at_min/max, etc.

🆕 Create Smart Collection
	•	Validates input body and rules
	•	Returns full created object

✏ Update Smart Collection
	•	PUT request to /smart_collections/{id}.json
	•	Request validated using Freezed model

❌ Delete Smart Collection
	•	Straightforward ID-based deletion

🔄 Update Product Ordering
	•	PUT to /smart_collections/{id}/order.json
	•	Supports reorder actions using product position

⚙ Technical Highlights
	•	🧱 Modular architecture: all endpoints use dedicated handlers
	•	🌐 Retrofit + Freezed for robust request modeling
	•	💉 Dependency injection with GetIt + Injectable
	•	📊 Timestamped response with clear status, data, and message
	•	🚫 Error-safe handler logic with consistent output format

🧪 Edge Cases Handled
	•	Missing or invalid ID, body, or query param
	•	Invalid method checks (Only GET/POST/PUT allowed errors)
	•	Shopify 400/500 error parsing and clear forwarding

🧰 Tech Stack
	•	🧩 Retrofit & Dio
	•	❄ Freezed & JsonSerializable
	•	💉 Injectable + GetIt
	•	🔎 Postman-tested & modular handlers

✅ Checklist
	•	SmartCollectionService interface updated
	•	Retrofit layer updated with all query support
	•	Handlers added for each action (list, single, count, create, update, delete, reorder)
	•	All requests are validated before sending
	•	Timestamped and consistent API responses
	•	Modular, reusable and DI-compatible structure
	•	Freezed model generation completed

🛠 Steps to Test

1. API Explorer
	•	Open OSMEA API Explorer
	•	Ensure Smart Collection endpoints are visible

2. List Smart Collections
	•	Test filters: title, fields, since_id, limit
	•	Confirm only requested fields are returned

3. Retrieve Single
	•	Provide a valid id
	•	Add fields param (e.g., id,title)

4. Count Smart Collections
	•	Test with and without filters
	•	Validate count matches expectations

5. Create Smart Collection
	•	Send valid body with rules, title, etc.
	•	Test required field errors

6. Update Smart Collection
	•	PUT with partial updates (e.g. just title)
	•	Verify 200 OK with updated fields

7. Delete Smart Collection
	•	Test valid and invalid IDs

8. Product Reordering
	•	PUT /order.json call with manual sort updates

9. Negative Testing
	•	Invalid methods (e.g. POST where only GET is allowed)
	•	Missing id or body on PUT/DELETE

10. DI Verification
	•	Confirm all services registered in GetIt
	•	Check Retrofit logs for correct API path/params


Contributors
@melihalkbk 


### 📷 Screenshots (Optional)
![1](https://github.com/user-attachments/assets/696fe090-b5ba-4785-bd7b-9c7890b0f650)
![2](https://github.com/user-attachments/assets/81a5e143-6fe6-4dd0-b785-a510b2d5ee10)
![3](https://github.com/user-attachments/assets/3a38aad6-a04f-42bc-afed-90ae42be3d29)
![4](https://github.com/user-attachments/assets/2018e064-a9e0-4f0f-a7c3-53c1a8de6c2b)
![5](https://github.com/user-attachments/assets/53a7ec9e-23c6-4dfc-b82b-bfdea2c7ac1c)
![6](https://github.com/user-attachments/assets/ccf9dd6d-a539-4363-ba76-3c5ad7a059bb)
![7](https://github.com/user-attachments/assets/21cfaafb-2db7-4f5e-b693-8aeffbd54da0)

