### PR TITLE
OSMEA - Components -> Radio Button

### DIFF
--- a/packages/components/lib/osmea_components.dart
+++ b/packages/components/lib/osmea_components.dart
@@ -22,6 +22,9 @@ export 'src/components/navbar/navbar.dart';
 // 🔄 Switches
 export 'src/components/switch_button/switch_button.dart';
 
+// 📻 Radio Buttons
+export 'src/components/radio_button/radio_button.dart';
+
 // ☑️ Checkbox
 // Checkbox component
 export 'src/components/checkbox/checkbox.dart';

--- a/packages/components/lib/src/components.dart
+++ b/packages/components/lib/src/components.dart
@@ -7,7 +7,9 @@ import 'package:osmea_components/src/components/navbar/navbar.dart';
 import 'package:osmea_components/src/components/switch_button/switch_button.dart';
 import 'package:osmea_components/src/enums/button_enums.dart';
 import 'package:osmea_components/src/enums/navbar_enums.dart';
+import 'package:osmea_components/src/components/radio_button/radio_button.dart';
 import 'package:osmea_components/src/enums/checkbox_enums.dart';
+import 'package:osmea_components/src/enums/radio_enums.dart';
 import 'package:osmea_components/src/enums/switch_enums.dart';
 import 'package:osmea_components/src/theme/theme.dart';
 
@@ -427,6 +429,74 @@ class OsmeaComponents {
       scrollable: scrollable,
       onItemTap: onItemTap,
       currentIndex: currentIndex,
+    );
+  }
+  /// OsmeaComponents.radioButton<String>(
+  ///   value: 'option1',
+  ///   groupValue: selectedOption,
+  ///   label: 'Select Option 1',
+  ///   description: 'This is the first option',
+  ///   variant: RadioVariant.labeled,
+  ///   size: RadioSize.medium,
+  ///   style: RadioStyle.modern,
+  ///   onChanged: (value) => setState(() => selectedOption = value),
+  /// )
+  /// ```
+  static Widget radioButton<T>({
+    Key? key,
+    CoreTheme? customTheme,
+    required T value,
+    required T? groupValue,
+    required ValueChanged<T?>? onChanged,
+    RadioSize size = RadioSize.medium,
+    RadioVariant variant = RadioVariant.simple,
+    RadioState state = RadioState.enabled,
+    RadioStyle style = RadioStyle.modern,
+    String? label,
+    String? description,
+    RadioLabelPosition labelPosition = RadioLabelPosition.trailing,
+    Color? activeColor,
+    Color? inactiveColor,
+    Color? dotColor,
+    Color? borderColor,
+    Color? focusColor,
+    Color? hoverColor,
+    EdgeInsetsGeometry? padding,
+    EdgeInsetsGeometry? margin,
+    Duration? animationDuration,
+    ValueChanged<bool>? onHover,
+    FocusNode? focusNode,
+    bool autofocus = false,
+    String? semanticLabel,
+    bool fullWidth = false,
+  }) {
+    return OsmeaRadio<T>(
+      key: key,
+      customTheme: customTheme,
+      value: value,
+      groupValue: groupValue,
+      onChanged: onChanged,
+      size: size,
+      variant: variant,
+      state: state,
+      style: style,
+      label: label,
+      description: description,
+      labelPosition: labelPosition,
+      activeColor: activeColor,
+      inactiveColor: inactiveColor,
+      dotColor: dotColor,
+      borderColor: borderColor,
+      focusColor: focusColor,
+      hoverColor: hoverColor,
+      padding: padding,
+      margin: margin,
+      animationDuration: animationDuration,
+      onHover: onHover,
+      focusNode: focusNode,
+      autofocus: autofocus,
+      semanticLabel: semanticLabel,
+      fullWidth: fullWidth,
     );
   }
 

--- a/packages/components/lib/src/components/radio_button/radio_button.dart
+++ b/packages/components/lib/src/components/radio_button/radio_button.dart
@@ -1,0 +1,586 @@
+import 'package:flutter/material.dart';
+import 'package:osmea_components/osmea_components.dart';
+import 'package:osmea_components/src/core/container_widget.dart';
+
+/// 🔘 **OSMEA Radio**
+///
+/// A modern, customizable radio button component with multiple styles and variants.
+/// Supports comprehensive selection functionality with rich visual feedback.
+class OsmeaRadio<T> extends CoreContainer {
+  const OsmeaRadio({
+    super.key,
+    super.customTheme,
+    required this.value,
+    required this.groupValue,
+    required this.onChanged,
+    this.size = RadioSize.medium,
+    this.variant = RadioVariant.simple,
+    this.state = RadioState.enabled,
+    this.style = RadioStyle.modern,
+    this.label,
+    this.description,
+    this.labelPosition = RadioLabelPosition.trailing,
+    this.activeColor,
+    this.inactiveColor,
+    this.dotColor,
+    this.borderColor,
+    this.focusColor,
+    this.hoverColor,
+    super.padding,
+    super.margin,
+    this.animationDuration,
+    this.onHover,
+    this.focusNode,
+    this.autofocus = false,
+    this.semanticLabel,
+    this.fullWidth = false,
+  });
+
+  /// 🎯 The value represented by this radio button
+  final T value;
+
+  /// 🔄 The currently selected value for this group of radio buttons
+  final T? groupValue;
+
+  /// 🖱️ Callback triggered when the radio button is selected
+  final ValueChanged<T?>? onChanged;
+
+  /// 📏 The size of the radio button
+  final RadioSize size;
+
+  /// 🎨 The visual style variant of the radio button
+  final RadioVariant variant;
+
+  /// 🔄 The current interactive state of the radio button
+  final RadioState state;
+
+  /// 🎭 The visual style of the radio button
+  final RadioStyle style;
+
+  /// 🏷️ Optional text label displayed next to the radio button
+  final String? label;
+
+  /// 📝 Optional description text displayed below the label
+  final String? description;
+
+  /// 📍 Position of the label relative to the radio button
+  final RadioLabelPosition labelPosition;
+
+  /// 🎨 Custom active state color
+  final Color? activeColor;
+
+  /// 🎨 Custom inactive state color
+  final Color? inactiveColor;
+
+  /// 🎯 Custom inner dot color
+  final Color? dotColor;
+
+  /// 🔲 Custom border color
+  final Color? borderColor;
+
+  /// 🎯 Color displayed when the radio button has focus
+  final Color? focusColor;
+
+  /// ✨ Color displayed when the user hovers over the radio button
+  final Color? hoverColor;
+
+  /// ⏱️ Duration for radio button animations
+  final Duration? animationDuration;
+
+  /// 🖱️ Callback triggered when hover state changes
+  final ValueChanged<bool>? onHover;
+
+  /// 🎯 Node for managing the focus state of the radio button
+  final FocusNode? focusNode;
+
+  /// 🔵 When true, the radio button will automatically request focus when displayed
+  final bool autofocus;
+
+  /// ♿ Semantic label for accessibility
+  final String? semanticLabel;
+
+  /// ↔️ Whether the radio button container should take the full width of its parent
+  final bool fullWidth;
+
+  // Computed properties based on state
+  bool get isSelected => value == groupValue;
+  bool get isDisabled => state == RadioState.disabled;
+  bool get isFocused => state == RadioState.focused;
+  bool get isHovered => state == RadioState.hovered;
+  bool get isEffectivelyDisabled => isDisabled || onChanged == null;
+
+  @override
+  Widget buildWidget(BuildContext context) {
+    final config = size.config(context);
+    final colors = _getRadioColors(context);
+
+    Widget radioWidget = _buildRadio(context, config, colors);
+
+    // Variant'a göre label gösterimi
+    if ((variant == RadioVariant.labeled ||
+            variant == RadioVariant.extended ||
+            variant == RadioVariant.card ||
+            variant == RadioVariant.tile) &&
+        (label != null || description != null)) {
+      radioWidget = _buildWithLabel(context, radioWidget, colors);
+    }
+
+    if (margin != null) {
+      radioWidget = Padding(padding: margin!, child: radioWidget);
+    }
+
+    if (semanticLabel != null) {
+      radioWidget = Semantics(
+        label: semanticLabel!,
+        value: isSelected ? 'Selected' : 'Not selected',
+        onTap: isEffectivelyDisabled ? null : () => onChanged?.call(value),
+        child: radioWidget,
+      );
+    }
+
+    return radioWidget;
+  }
+
+  Widget _buildRadio(
+    BuildContext context,
+    RadioSizeConfig config,
+    _RadioColors colors,
+  ) {
+    return AnimatedContainer(
+      duration: animationDuration ?? const Duration(milliseconds: 200),
+      curve: Curves.easeInOutCubic,
+      child: Focus(
+        focusNode: focusNode,
+        autofocus: autofocus,
+        onFocusChange: (focused) {
+          // Note: Since this is now stateless, we cannot track focus state
+          // The focus behavior will be handled by the focus node itself
+        },
+        child: GestureDetector(
+          onTap: isEffectivelyDisabled ? null : () => onChanged?.call(value),
+          child: MouseRegion(
+            cursor: isEffectivelyDisabled
+                ? SystemMouseCursors.forbidden
+                : SystemMouseCursors.click,
+            onEnter: (event) {
+              onHover?.call(true);
+            },
+            onExit: (event) {
+              onHover?.call(false);
+            },
+            child: _buildRadioCircle(context, config, colors),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildRadioCircle(
+    BuildContext context,
+    RadioSizeConfig config,
+    _RadioColors colors,
+  ) {
+    return AnimatedContainer(
+      duration: animationDuration ?? const Duration(milliseconds: 200),
+      curve: Curves.easeInOutCubic,
+      width: config.outerSize,
+      height: config.outerSize,
+      decoration: _getOuterDecoration(context, config, colors),
+      child: Center(
+        child: AnimatedContainer(
+          duration: animationDuration ?? const Duration(milliseconds: 200),
+          curve: Curves.easeInOutCubic,
+          width: isSelected ? config.innerSize : 0,
+          height: isSelected ? config.innerSize : 0,
+          decoration: _getInnerDecoration(context, config, colors),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildWithLabel(
+    BuildContext context,
+    Widget radioWidget,
+    _RadioColors colors,
+  ) {
+    Widget labelWidget = _buildLabelWidget(context, colors);
+
+    List<Widget> children = labelPosition == RadioLabelPosition.leading
+        ? [labelWidget, radioWidget]
+        : [radioWidget, labelWidget];
+
+    Widget content = Row(
+      mainAxisSize: fullWidth ? MainAxisSize.max : MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: children,
+    );
+
+    // Card ve tile variant'ları için container
+    if (variant == RadioVariant.card || variant == RadioVariant.tile) {
+      content = _wrapInContainer(context, content, colors);
+    }
+
+    return content;
+  }
+
+  Widget _buildLabelWidget(BuildContext context, _RadioColors colors) {
+    return Expanded(
+      flex: fullWidth ? 1 : 0,
+      child: Padding(
+        padding: labelPosition == RadioLabelPosition.leading
+            ? EdgeInsets.only(right: context.lowValue)
+            : EdgeInsets.only(left: context.lowValue),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            if (label != null)
+              Text(
+                label!,
+                style: _getEffectiveLabelStyle(context).copyWith(
+                  color: isEffectivelyDisabled
+                      ? colors.disabledText
+                      : colors.text,
+                ),
+              ),
+            if (description != null) ...[
+              SizedBox(height: context.lowValue * 0.25),
+              Text(
+                description!,
+                style: _getEffectiveDescriptionStyle(context).copyWith(
+                  color: isEffectivelyDisabled
+                      ? colors.disabledText
+                      : colors.text.withValues(alpha: 0.7),
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _wrapInContainer(
+    BuildContext context,
+    Widget content,
+    _RadioColors colors,
+  ) {
+    return AnimatedContainer(
+      duration: animationDuration ?? const Duration(milliseconds: 200),
+      curve: Curves.easeInOutCubic,
+      width: fullWidth ? double.infinity : null,
+      padding: variant == RadioVariant.tile
+          ? EdgeInsets.all(context.normalValue)
+          : EdgeInsets.all(context.lowValue),
+      decoration: _getContainerDecoration(context, colors),
+      child: content,
+    );
+  }
+
+  BoxDecoration _getOuterDecoration(
+    BuildContext context,
+    RadioSizeConfig config,
+    _RadioColors colors,
+  ) {
+    final baseColor = isSelected ? colors.activeOuter : colors.inactiveOuter;
+    final borderColor = isSelected ? colors.activeBorder : colors.inactiveBorder;
+
+    switch (style) {
+      case RadioStyle.material:
+        return BoxDecoration(
+          color: baseColor,
+          shape: BoxShape.circle,
+          border: Border.all(
+            color: borderColor,
+            width: config.borderWidth,
+          ),
+          boxShadow: isFocused && !isEffectivelyDisabled
+              ? [
+                  BoxShadow(
+                    color: colors.focus.withValues(alpha: 0.3),
+                    offset: const Offset(0, 0),
+                    blurRadius: 8,
+                    spreadRadius: 2,
+                  ),
+                ]
+              : null,
+        );
+
+      case RadioStyle.cupertino:
+        return BoxDecoration(
+          color: baseColor,
+          shape: BoxShape.circle,
+          border: Border.all(
+            color: borderColor,
+            width: config.borderWidth,
+          ),
+        );
+
+      case RadioStyle.modern:
+        return BoxDecoration(
+          color: baseColor,
+          shape: BoxShape.circle,
+          border: Border.all(
+            color: borderColor,
+            width: config.borderWidth,
+          ),
+          boxShadow: isHovered && !isEffectivelyDisabled
+              ? [
+                  BoxShadow(
+                    color: colors.hover.withValues(alpha: 0.2),
+                    offset: const Offset(0, 2),
+                    blurRadius: 8,
+                    spreadRadius: 0,
+                  ),
+                ]
+              : null,
+        );
+      case RadioStyle.glassmorphism:
+        return BoxDecoration(
+          color: baseColor.withValues(alpha: 0.2),
+          shape: BoxShape.circle,
+          border: Border.all(
+            color: OsmeaColors.white.withValues(alpha: 0.3),
+            width: config.borderWidth,
+          ),
+          boxShadow: [
+            BoxShadow(
+              color: OsmeaColors.shadowLight.withValues(alpha: 0.1),
+              offset: const Offset(0, 8),
+              blurRadius: 32,
+              spreadRadius: 0,
+            ),
+          ],
+        );
+
+      case RadioStyle.minimal:
+        return BoxDecoration(
+          color: baseColor,
+          shape: BoxShape.circle,
+          border: Border.all(
+            color: isFocused && !isEffectivelyDisabled
+                ? colors.focus
+                : borderColor,
+            width: config.borderWidth,
+          ),
+        );
+
+      case RadioStyle.custom:
+      default:
+        return BoxDecoration(
+          color: baseColor,
+          shape: BoxShape.circle,
+          border: Border.all(
+            color: borderColor,
+            width: config.borderWidth,
+          ),
+        );
+    }
+  }
+
+  BoxDecoration _getInnerDecoration(
+    BuildContext context,
+    RadioSizeConfig config,
+    _RadioColors colors,
+  ) {
+    return BoxDecoration(
+      color: colors.innerDot,
+      shape: BoxShape.circle,
+    );
+  }
+
+  BoxDecoration _getContainerDecoration(
+    BuildContext context,
+    _RadioColors colors,
+  ) {
+    switch (variant) {
+      case RadioVariant.card:
+        return BoxDecoration(
+          color: isSelected ? colors.activeContainer : colors.inactiveContainer,
+          borderRadius: BorderRadius.circular(context.radiusLow.toDouble()),
+          border: Border.all(
+            color: isSelected ? colors.activeBorder : colors.inactiveBorder,
+            width: 1,
+          ),
+          boxShadow: [
+            BoxShadow(
+              color: OsmeaColors.shadowLight.withValues(alpha: 0.1),
+              offset: const Offset(0, 2),
+              blurRadius: 8,
+              spreadRadius: 0,
+            ),
+          ],
+        );
+
+      case RadioVariant.tile:
+        return BoxDecoration(
+          color: isSelected ? colors.activeContainer : colors.inactiveContainer,
+          borderRadius: BorderRadius.circular(context.radiusLow.toDouble()),
+          border: isSelected
+              ? Border.all(
+                  color: colors.activeBorder,
+                  width: 1,
+                )
+              : null,
+        );
+
+      default:
+        return const BoxDecoration();
+    }
+  }
+
+  TextStyle _getEffectiveLabelStyle(BuildContext context) {
+    switch (size) {
+      case RadioSize.small:
+        return OsmeaTextStyle.labelSmall(context);
+      case RadioSize.medium:
+        return OsmeaTextStyle.labelMedium(context);
+      case RadioSize.large:
+        return OsmeaTextStyle.labelLarge(context);
+    }
+  }
+
+  TextStyle _getEffectiveDescriptionStyle(BuildContext context) {
+    return OsmeaTextStyle.captionMedium(context);
+  }
+
+  _RadioColors _getRadioColors(BuildContext context) {
+    final theme = Theme.of(context);
+    final primaryColor = activeColor ?? theme.colorScheme.primary;
+    final surfaceColor = theme.colorScheme.surface;
+    final onSurfaceColor = theme.colorScheme.onSurface;
+
+    return _RadioColors(
+      activeOuter: primaryColor.withValues(alpha: 0.1),
+      inactiveOuter: surfaceColor,
+      activeBorder: primaryColor,
+      inactiveBorder: onSurfaceColor.withValues(alpha: 0.3),
+      innerDot: dotColor ?? primaryColor,
+      text: onSurfaceColor,
+      focus: focusColor ?? primaryColor.withValues(alpha: 0.8),
+      hover: hoverColor ?? primaryColor.withValues(alpha: 0.1),
+      disabledText: onSurfaceColor.withValues(alpha: 0.4),
+      activeContainer: primaryColor.withValues(alpha: 0.05),
+      inactiveContainer: surfaceColor,
+    );
+  }
+}
+
+/// Internal helper class for radio button colors
+class _RadioColors {
+  final Color activeOuter;
+  final Color inactiveOuter;
+  final Color activeBorder;
+  final Color inactiveBorder;
+  final Color innerDot;
+  final Color text;
+  final Color focus;
+  final Color hover;
+  final Color disabledText;
+  final Color activeContainer;
+  final Color inactiveContainer;
+
+  const _RadioColors({
+    required this.activeOuter,
+    required this.inactiveOuter,
+    required this.activeBorder,
+    required this.inactiveBorder,
+    required this.innerDot,
+    required this.text,
+    required this.focus,
+    required this.hover,
+    required this.disabledText,
+    required this.activeContainer,
+    required this.inactiveContainer,
+  });
+}
+
+/// 🏷️ **OSMEA Labeled Radio**
+class OsmeaLabeledRadio<T> extends OsmeaRadio<T> {
+  const OsmeaLabeledRadio({
+    super.key,
+    required super.value,
+    required super.groupValue,
+    required String label,
+    String? description,
+    super.size,
+    super.state,
+    super.onChanged,
+    super.labelPosition,
+    super.customTheme,
+    super.fullWidth,
+    super.activeColor,
+    super.inactiveColor,
+    super.style,
+  }) : super(
+          label: label,
+          description: description,
+          variant: RadioVariant.labeled,
+        );
+}
+
+/// 🎯 **OSMEA Simple Radio**
+class OsmeaSimpleRadio<T> extends OsmeaRadio<T> {
+  const OsmeaSimpleRadio({
+    super.key,
+    required super.value,
+    required super.groupValue,
+    super.size,
+    super.state,
+    super.onChanged,
+    super.customTheme,
+    super.activeColor,
+    super.inactiveColor,
+    super.style,
+  }) : super(
+          variant: RadioVariant.simple,
+        );
+}
+
+/// 📦 **OSMEA Card Radio**
+class OsmeaCardRadio<T> extends OsmeaRadio<T> {
+  const OsmeaCardRadio({
+    super.key,
+    required super.value,
+    required super.groupValue,
+    required String label,
+    String? description,
+    super.size,
+    super.state,
+    super.onChanged,
+    super.labelPosition,
+    super.customTheme,
+    super.fullWidth = true,
+    super.activeColor,
+    super.inactiveColor,
+    super.style,
+  }) : super(
+          label: label,
+          description: description,
+          variant: RadioVariant.card,
+        );
+}
+
+/// 📋 **OSMEA Tile Radio**
+class OsmeaTileRadio<T> extends OsmeaRadio<T> {
+  const OsmeaTileRadio({
+    super.key,
+    required super.value,
+    required super.groupValue,
+    required String label,
+    String? description,
+    super.size,
+    super.state,
+    super.onChanged,
+    super.labelPosition,
+    super.customTheme,
+    super.fullWidth = true,
+    super.activeColor,
+    super.inactiveColor,
+    super.style,
+  }) : super(
+          label: label,
+          description: description,
+          variant: RadioVariant.tile,
+        );
+}

--- a/packages/components/lib/src/enums/enums.dart
+++ b/packages/components/lib/src/enums/enums.dart
@@ -23,6 +23,9 @@ export 'button_enums.dart';
 // 🔄 Switch-related enums
 export 'switch_enums.dart';
 
+// 📻 Radio button enums
+export 'radio_enums.dart';
+
 // ☑️ Checkbox enums
 export 'checkbox_enums.dart';
 

--- a/packages/components/lib/src/enums/radio_enums.dart
+++ b/packages/components/lib/src/enums/radio_enums.dart
@@ -1,0 +1,268 @@
+/// 🔘 **OSMEA Radio Enums**
+///
+/// Copyright (c) 2025, OSMEA Team
+/// https://github.com/osmea/components
+///
+/// Comprehensive enum definitions for radio button components.
+///
+/// {@category Enums}
+/// {@subCategory Radio}
+///
+/// Enums:
+/// * 📏 RadioSize - Size variants for radio buttons
+/// * 🎨 RadioVariant - Style variants for radio buttons
+/// * 🔄 RadioState - Interactive states for radio buttons
+/// * 📍 RadioStyle - Radio visual style options
+///
+/// ```dart
+/// OsmeaRadio(
+///   value: 'option1',
+///   groupValue: selectedOption,
+///   size: RadioSize.medium,
+///   variant: RadioVariant.labeled,
+///   onChanged: (value) => setState(() => selectedOption = value),
+/// )
+/// ```
+
+/// 📏 **Radio Size Variants**
+///
+/// Defines the available size options for all radio button components.
+/// Each size has specific dimensions, padding, and proportional scaling.
+///
+/// **Size Guidelines:**
+/// - `small`: Compact radio buttons for tight spaces (16px diameter)
+/// - `medium`: Standard radio button size for most use cases (20px diameter)
+/// - `large`: Prominent radio buttons for accessibility (24px diameter)
+///
+/// **Usage:**
+/// ```dart
+/// OsmeaRadio(
+///   value: 'option1',
+///   groupValue: selectedValue,
+///   size: RadioSize.medium, // Standard size
+///   onChanged: (value) => setState(() => selectedValue = value),
+/// )
+/// ```
+enum RadioSize {
+  /// 🔸 **Small** - Compact radio buttons for constrained spaces
+  /// - Diameter: 16px
+  /// - Inner dot: 6px diameter
+  /// - Use for: Dense layouts, table rows, inline forms
+  small,
+
+  /// 🔶 **Medium** - Standard radio button size for most interfaces
+  /// - Diameter: 20px
+  /// - Inner dot: 8px diameter
+  /// - Use for: Forms, settings panels, general use
+  medium,
+
+  /// 🔷 **Large** - Prominent radio buttons for accessibility
+  /// - Diameter: 24px
+  /// - Inner dot: 10px diameter
+  /// - Use for: Important selections, accessibility, mobile interfaces
+  large,
+}
+
+/// 🎨 **Radio Style Variants**
+///
+/// Defines the structural and behavioral variants for radio button components.
+/// Each variant represents a different radio type with specific features and layout.
+///
+/// **Structural Variants:**
+/// - `simple`: Basic radio button without any labels or descriptions
+/// - `labeled`: Radio button with text label support
+/// - `card`: Radio button embedded in a card-like container
+/// - `tile`: Radio button as a list tile with enhanced layout
+/// - `compact`: Minimal space radio button for dense layouts
+/// - `extended`: Full-featured radio button with maximum customization
+///
+/// **Usage:**
+/// ```dart
+/// OsmeaRadio(
+///   value: 'option1',
+///   groupValue: selectedValue,
+///   variant: RadioVariant.labeled, // Radio with label support
+///   onChanged: (value) => _handleSelection(value),
+/// )
+/// ```
+enum RadioVariant {
+  /// 🎯 **Simple** - Basic radio button without labels
+  /// - Minimal design
+  /// - No text labels or descriptions
+  /// - Pure selection functionality
+  /// - Use for: Simple selections, compact layouts, icon-only radios
+  simple,
+
+  /// 🏷️ **Labeled** - Radio button with label support
+  /// - Includes text label
+  /// - Optional description text
+  /// - Standard radio button with text
+  /// - Use for: Forms, preference screens, option lists
+  labeled,
+
+  /// 📦 **Card** - Radio button embedded in card container
+  /// - Card-like background
+  /// - Enhanced visual separation
+  /// - Elevated appearance
+  /// - Use for: Settings lists, option cards, grouped choices
+  card,
+
+  /// 📋 **Tile** - Radio button as list tile
+  /// - List tile layout
+  /// - Title and subtitle support
+  /// - Enhanced touch target
+  /// - Use for: Option lists, settings menus, selection screens
+  tile,
+
+  /// 📦 **Compact** - Minimal space radio button
+  /// - Smallest possible size
+  /// - Optimized for dense layouts
+  /// - Reduced padding and margins
+  /// - Use for: Table rows, inline forms, toolbar options
+  compact,
+
+  /// 🔧 **Extended** - Full-featured radio button
+  /// - Maximum customization options
+  /// - Advanced styling capabilities
+  /// - All features enabled
+  /// - Use for: Complex interfaces, custom designs, specialized needs
+  extended,
+}
+
+/// 🔄 **Radio Interactive States**
+///
+/// Defines the current interactive state of a radio button component.
+/// These states affect visual appearance and user interaction.
+///
+/// **State Guidelines:**
+/// - `enabled`: Normal interactive state
+/// - `disabled`: Non-interactive state
+/// - `focused`: Keyboard focus state
+/// - `hovered`: Mouse hover state
+///
+/// **Usage:**
+/// ```dart
+/// OsmeaRadio(
+///   value: 'option1',
+///   groupValue: selectedValue,
+///   state: isFormValid ? RadioState.enabled : RadioState.disabled,
+///   onChanged: isFormValid ? (value) => _handleChange(value) : null,
+/// )
+/// ```
+enum RadioState {
+  /// ✅ **Enabled** - Normal interactive state
+  /// - Full opacity and colors
+  /// - Responds to user interaction
+  /// - Default state for functional radio buttons
+  enabled,
+
+  /// ⚫ **Disabled** - Non-interactive state
+  /// - Reduced opacity (typically 50%)
+  /// - Gray appearance
+  /// - No response to user interaction
+  disabled,
+
+  /// 🎯 **Focused** - Keyboard focus state
+  /// - Focus ring or outline
+  /// - Accessible via keyboard navigation
+  /// - Important for accessibility
+  focused,
+
+  /// 🖱️ **Hovered** - Mouse hover state
+  /// - Subtle visual feedback
+  /// - Desktop interaction indication
+  hovered,
+}
+
+/// 🎭 **Radio Style Options**
+///
+/// Defines different visual styles for radio button appearance.
+/// Each style creates a completely different look and feel.
+///
+/// **Modern Style Guidelines:**
+/// - `material`: Google Material Design 3 style
+/// - `cupertino`: Apple iOS style with smooth animations
+/// - `modern`: Contemporary flat design with subtle shadows
+/// - `glassmorphism`: Transparent glass-like appearance
+/// - `minimal`: Ultra-clean minimal design
+/// - `custom`: Full control for brand-specific designs
+///
+/// **Usage:**
+/// ```dart
+/// OsmeaRadio(
+///   value: 'option1',
+///   groupValue: selectedValue,
+///   style: RadioStyle.cupertino, // Soft UI appearance
+///   onChanged: (value) => _updateState(value),
+/// )
+/// ```
+enum RadioStyle {
+  /// 📱 **Material** - Material Design 3 style
+  /// - Circular border with Material ripples
+  /// - Material Design animations and colors
+  /// - Google design system compliance
+  material,
+
+  /// 🍎 **Cupertino** - iOS style
+  /// - Clean circular border
+  /// - iOS-like smooth animations
+  /// - Apple Human Interface Guidelines
+  cupertino,
+
+  /// ✨ **Modern** - Contemporary flat design
+  /// - Clean lines with subtle shadows
+  /// - Smooth transitions and hover effects
+  /// - Balanced between minimal and rich
+  modern,
+
+  /// 💎 **Glassmorphism** - Glass-like transparency
+  /// - Semi-transparent backgrounds
+  /// - Backdrop blur effects
+  /// - Modern, ethereal appearance
+  glassmorphism,
+
+  /// 🔲 **Minimal** - Ultra-clean design
+  /// - No shadows or effects
+  /// - Pure geometric shapes
+  /// - Perfect for clean, focused interfaces
+  minimal,
+
+  /// 🎨 **Custom** - Full customization
+  /// - Complete control over appearance
+  /// - Custom animations and effects
+  /// - Brand-specific implementations
+  custom,
+}
+
+/// 📍 **Radio Label Position**
+///
+/// Defines where the label appears relative to the radio button component.
+///
+/// **Position Guidelines:**
+/// - `leading`: Label appears before the radio button (left in LTR)
+/// - `trailing`: Label appears after the radio button (right in LTR)
+///
+/// **Usage:**
+/// ```dart
+/// OsmeaRadio(
+///   value: 'option1',
+///   groupValue: selectedValue,
+///   label: 'Select Option',
+///   labelPosition: RadioLabelPosition.trailing, // Label after radio
+///   onChanged: (value) => _updateState(value),
+/// )
+/// ```
+enum RadioLabelPosition {
+  /// ⬅️ **Leading** - Label before radio button
+  /// - Label positioned before the radio button
+  /// - Left side in LTR languages
+  /// - Right side in RTL languages
+  leading,
+
+  /// ➡️ **Trailing** - Label after radio button
+  /// - Label positioned after the radio button
+  /// - Right side in LTR languages
+  /// - Left side in RTL languages
+  /// - Default and most common position
+  trailing,
+}

--- a/packages/components/lib/src/utils/radio_size_extensions.dart
+++ b/packages/components/lib/src/utils/radio_size_extensions.dart
@@ -1,0 +1,193 @@
+/// 🔘 **OSMEA Radio Size Extensions**
+///
+/// Copyright (c) 2025, OSMEA Team
+/// https://github.com/osmea/components
+///
+/// Provides comprehensive radio button sizing utilities for the OSMEA Design System.
+/// This file contains extensions for:
+///
+/// - 📏 Radio sizes (small to large)
+/// - 📦 Padding configurations
+/// - 🔲 Border radius utilities
+/// - 🎯 Inner dot size helpers
+/// - 📊 Outer circle dimensions
+///
+/// @author OSMEA UI Team
+/// @category Components
+/// @subcategory Utils
+
+import 'package:flutter/material.dart';
+import 'package:osmea_components/src/enums/radio_enums.dart';
+import 'package:osmea_components/src/utils/sizer_extensions.dart';
+
+/// 🔘 **Radio Size Extensions**
+///
+/// Provides consistent radio button sizing across the OSMEA UI Kit.
+/// Use these extensions to maintain visual hierarchy and touch targets.
+///
+/// ---
+///
+/// **Size Categories:**
+/// - `small` 📱: Compact radio buttons for dense layouts
+/// - `medium` 🎯: Standard radio button size (recommended)
+/// - `large` 🖱️: Prominent radio buttons for accessibility
+///
+/// ---
+///
+/// _Example:_
+/// ```dart
+/// Radio(
+///   value: 'option1',
+///   groupValue: selectedValue,
+///   onChanged: (value) => setState(() => selectedValue = value),
+///   materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+/// )
+/// ```
+extension RadioSizeExtension on BuildContext {
+  /// 📱 **Small Radio**
+  /// - Outer circle: 16px diameter
+  /// - Inner dot: 6px diameter
+  /// - Use for: Dense layouts, table rows
+  double get radioSizeSmall => allHeight * 0.02;
+
+  /// 🎯 **Medium Radio** (Recommended)
+  /// - Outer circle: 20px diameter
+  /// - Inner dot: 8px diameter
+  /// - Use for: Standard forms, options
+  double get radioSizeMedium => allHeight * 0.025;
+
+  /// 🖱️ **Large Radio**
+  /// - Outer circle: 24px diameter
+  /// - Inner dot: 10px diameter
+  /// - Use for: Accessibility, prominent selections
+  double get radioSizeLarge => allHeight * 0.03;
+
+  /// Fixed size versions for specific layouts
+  double radioSizeSmallFixed(double size) => size * 0.8;
+  double radioSizeMediumFixed(double size) => size;
+  double radioSizeLargeFixed(double size) => size * 1.2;
+}
+
+/// 📏 **Radio Inner Dot Size Extensions**
+///
+/// Provides appropriate inner dot sizes for different radio button sizes.
+extension RadioInnerDotSizeExtension on BuildContext {
+  /// Small Radio Inner Dot Size
+  double get radioInnerDotSizeSmall => radioSizeSmall * 0.375; // 6px for 16px outer
+
+  /// Medium Radio Inner Dot Size
+  double get radioInnerDotSizeMedium => radioSizeMedium * 0.4; // 8px for 20px outer
+
+  /// Large Radio Inner Dot Size
+  double get radioInnerDotSizeLarge => radioSizeLarge * 0.416; // 10px for 24px outer
+}
+
+/// 📏 **Radio Padding Extensions**
+///
+/// Provides appropriate padding for different radio button sizes.
+extension RadioPaddingExtension on BuildContext {
+  /// Small Radio Padding
+  EdgeInsets get radioPaddingSmall => EdgeInsets.symmetric(
+        horizontal: lowValue * 0.5,
+        vertical: lowValue * 0.3,
+      );
+
+  /// Medium Radio Padding
+  EdgeInsets get radioPaddingMedium => EdgeInsets.symmetric(
+        horizontal: lowValue * 0.8,
+        vertical: lowValue * 0.5,
+      );
+
+  /// Large Radio Padding
+  EdgeInsets get radioPaddingLarge => EdgeInsets.symmetric(
+        horizontal: normalValue,
+        vertical: lowValue * 0.8,
+      );
+
+  /// Radio container padding
+  EdgeInsets get radioContainerPadding => EdgeInsets.all(lowValue * 0.5);
+}
+
+/// 🔘 **Radio Border Radius Extensions**
+///
+/// Provides consistent border radius for radio button components.
+extension RadioBorderRadiusExtension on BuildContext {
+  /// Radio outer circle border radius (always circular)
+  BorderRadius get radioOuterBorderRadius => BorderRadius.circular(radiusHigh);
+
+  /// Radio inner dot border radius (always circular)
+  BorderRadius get radioInnerBorderRadius => BorderRadius.circular(radiusHigh);
+
+  /// Radio container border radius for card variants
+  BorderRadius get radioContainerBorderRadius => BorderRadius.circular(radiusLow);
+}
+
+/// 🎨 **Radio Configuration Helper**
+///
+/// Helper class to get complete radio button configuration
+class RadioSizeConfig {
+  final double outerSize;
+  final double innerSize;
+  final EdgeInsets padding;
+  final BorderRadius outerBorderRadius;
+  final BorderRadius innerBorderRadius;
+  final double borderWidth;
+  final double tapTargetSize;
+
+  const RadioSizeConfig({
+    required this.outerSize,
+    required this.innerSize,
+    required this.padding,
+    required this.outerBorderRadius,
+    required this.innerBorderRadius,
+    required this.borderWidth,
+    required this.tapTargetSize,
+  });
+
+  /// Get complete configuration for small radio button
+  static RadioSizeConfig small(BuildContext context) => RadioSizeConfig(
+        outerSize: context.radioSizeSmall,
+        innerSize: context.radioInnerDotSizeSmall,
+        padding: context.radioPaddingSmall,
+        outerBorderRadius: context.radioOuterBorderRadius,
+        innerBorderRadius: context.radioInnerBorderRadius,
+        borderWidth: 1.5,
+        tapTargetSize: context.radioSizeSmall + (context.lowValue * 0.8),
+      );
+
+  /// Get complete configuration for medium radio button
+  static RadioSizeConfig medium(BuildContext context) => RadioSizeConfig(
+        outerSize: context.radioSizeMedium,
+        innerSize: context.radioInnerDotSizeMedium,
+        padding: context.radioPaddingMedium,
+        outerBorderRadius: context.radioOuterBorderRadius,
+        innerBorderRadius: context.radioInnerBorderRadius,
+        borderWidth: 2.0,
+        tapTargetSize: context.radioSizeMedium + (context.lowValue),
+      );
+
+  /// Get complete configuration for large radio button
+  static RadioSizeConfig large(BuildContext context) => RadioSizeConfig(
+        outerSize: context.radioSizeLarge,
+        innerSize: context.radioInnerDotSizeLarge,
+        padding: context.radioPaddingLarge,
+        outerBorderRadius: context.radioOuterBorderRadius,
+        innerBorderRadius: context.radioInnerBorderRadius,
+        borderWidth: 2.5,
+        tapTargetSize: context.radioSizeLarge + (context.lowValue * 1.2),
+      );
+}
+
+/// Extension to get the RadioSizeConfig for a RadioSize value.
+extension RadioSizeConfigGetter on RadioSize {
+  RadioSizeConfig config(BuildContext context) {
+    switch (this) {
+      case RadioSize.small:
+        return RadioSizeConfig.small(context);
+      case RadioSize.medium:
+        return RadioSizeConfig.medium(context);
+      case RadioSize.large:
+        return RadioSizeConfig.large(context);
+    }
+  }
+}


### PR DESCRIPTION
## 📋 PR Description

This PR introduces the **OSMEA Radio Button**, a powerful and fully customizable radio input system built for scalability, accessibility, and design flexibility. It includes full enum coverage, interactive styling, and developer-friendly integration.


A modular and stylable radio button widget supporting all modern UX patterns.

### ✅ Features

| Feature              | Description                                                                 |
|----------------------|-----------------------------------------------------------------------------|
| Size Variants        | `small`, `medium`, `large`                                                  |
| Structural Variants  | `simple`, `labeled`, `card`, `tile`, `compact`, `extended`                 |
| Interaction States   | `enabled`, `disabled`, `focused`, `hovered`                                 |
| Style Options        | `material`, `cupertino`, `modern`, `glassmorphism`, `minimal`, `custom`     |
| Label Positioning    | `leading`, `trailing`                                                       |
| Full Accessibility   | Keyboard focus, visual feedback, proper ARIA roles                         |
| Flexible Grouping    | Group-based selection behavior with `groupValue`                           |

### 📦 Enums Added

### `RadioSize`
Defines component sizing:
- `small` (16px)
- `medium` (20px)
- `large` (24px)

### `RadioVariant`
Different structural layouts:
- `simple`, `labeled`, `card`, `tile`, `compact`, `extended`

### `RadioState`
Interaction states for UI feedback:
- `enabled`, `disabled`, `focused`, `hovered`

### `RadioStyle`
Visual design flavors:
- `material`, `cupertino`, `modern`, `glassmorphism`, `minimal`, `custom`

### `RadioLabelPosition`
Label location:
- `leading`, `trailing`


## ✅ Checklist

- [x] Code follows the project standards and guidelines.
- [x] Relevant unit tests are written and all tests are passing.
- [ ] Test coverage is adequate for the changes.
- [x] Any unnecessary files or debug statements have been removed.
- [ ] Documentation is updated where necessary.
- [x] The PR has been reviewed by at least one team member before merging.

---

## 🛠 Steps to Test

1. **Import the Component**
   - Ensure `OsmeaRadio` and its related enums are properly imported:
     ```dart
     import 'package:osmea/components.dart';
     ```

2. **Basic Usage**
   - Add a basic `OsmeaRadio` to your widget tree:
     ```dart
     OsmeaComponents.radioButton(
       value: 'option1',
       groupValue: selectedOption,
       onChanged: (val) => setState(() => selectedOption = val),
     );
     ```

3. **Test Size Variants**
   - Change `RadioSize` to test sizing:
     ```dart
     size: RadioSize.small
     size: RadioSize.medium
     size: RadioSize.large
     ```

4. **Test Variants**
   - Use all `RadioVariant` values:
     ```dart
     variant: RadioVariant.simple
     variant: RadioVariant.labeled
     variant: RadioVariant.card
     variant: RadioVariant.tile
     variant: RadioVariant.compact
     variant: RadioVariant.extended
     ```

5. **Test Visual Styles**
   - Test with different `RadioStyle`:
     ```dart
     style: RadioStyle.material
     style: RadioStyle.cupertino
     style: RadioStyle.modern
     style: RadioStyle.glassmorphism
     style: RadioStyle.minimal
     style: RadioStyle.custom
     ```

6. **Label Positioning**
   - Verify correct label alignment:
     ```dart
     label: 'Radio Option',
     labelPosition: RadioLabelPosition.leading
     labelPosition: RadioLabelPosition.trailing
     ```

7. **Test Interactive States**
   - Ensure `RadioState` values work as expected:
     ```dart
     state: RadioState.enabled
     state: RadioState.disabled
     state: RadioState.focused
     state: RadioState.hovered
     ```

8. **Group Behavior**
   - Ensure only one option is selected at a time when using a shared `groupValue`.

9. **Accessibility**
   - Use keyboard to focus/select.
   - Use screen reader tools to verify proper accessibility.

10. **Custom Theming**
    - Test with app theme overrides or parent containers to verify style flexibility.

