### PR TITLE
OSMEA - FIX - Components -> Switch 

### DIFF
--- a/packages/components/lib/src/components/switch_button/switch_button.dart
+++ b/packages/components/lib/src/components/switch_button/switch_button.dart
@@ -299,41 +299,6 @@ class OsmeaSwitch extends CoreContainer {
           ],
         );
 
-      case SwitchStyle.neumorphism:
-        return BoxDecoration(
-          color: value ? colors.activeTrack : OsmeaColors.ash,
-          borderRadius: BorderRadius.circular(config.trackSize.height / 2),
-          boxShadow: value
-              ? [
-                  BoxShadow(
-                    color: colors.activeTrack.withValues(alpha: 0.4),
-                    offset: const Offset(-2, -2),
-                    blurRadius: 4,
-                    spreadRadius: 0,
-                  ),
-                  BoxShadow(
-                    color: colors.activeTrack.withValues(alpha: 0.2),
-                    offset: const Offset(2, 2),
-                    blurRadius: 4,
-                    spreadRadius: 0,
-                  ),
-                ]
-              : [
-                  const BoxShadow(
-                    color: OsmeaColors.white,
-                    offset: Offset(-2, -2),
-                    blurRadius: 4,
-                    spreadRadius: 0,
-                  ),
-                  BoxShadow(
-                    color: OsmeaColors.pewter.withValues(alpha: 0.3),
-                    offset: const Offset(2, 2),
-                    blurRadius: 4,
-                    spreadRadius: 0,
-                  ),
-                ],
-        );
-
       case SwitchStyle.glassmorphism:
         return BoxDecoration(
           color: (value ? colors.activeTrack : colors.inactiveTrack)
@@ -440,28 +405,6 @@ class OsmeaSwitch extends CoreContainer {
             color: OsmeaColors.white.withValues(alpha: 0.3),
             width: 0.5,
           ),
-        );
-
-      case SwitchStyle.neumorphism:
-        return BoxDecoration(
-          color: colors.thumb,
-          borderRadius: BorderRadius.circular(config.thumbSize / 2),
-          boxShadow: [
-            if (!isEffectivelyDisabled) ...[
-              const BoxShadow(
-                color: OsmeaColors.white,
-                offset: Offset(-1, -1),
-                blurRadius: 2,
-                spreadRadius: 0,
-              ),
-              BoxShadow(
-                color: OsmeaColors.pewter.withValues(alpha: 0.4),
-                offset: const Offset(1, 1),
-                blurRadius: 2,
-                spreadRadius: 0,
-              ),
-            ],
-          ],
         );
 
       case SwitchStyle.glassmorphism:

--- a/packages/components/lib/src/enums/switch_enums.dart
+++ b/packages/components/lib/src/enums/switch_enums.dart
@@ -187,7 +187,6 @@ enum SwitchState {
 /// - `material`: Google Material Design 3 style
 /// - `cupertino`: Apple iOS style with smooth animations
 /// - `modern`: Contemporary flat design with subtle shadows
-/// - `neumorphism`: Soft UI with inset/outset effects
 /// - `glassmorphism`: Transparent glass-like appearance
 /// - `minimal`: Ultra-clean minimal design
 /// - `custom`: Full control for brand-specific designs
@@ -196,7 +195,7 @@ enum SwitchState {
 /// ```dart
 /// OsmeaSwitch(
 ///   value: isOn,
-///   style: SwitchStyle.neumorphism, // Soft UI appearance
+///   style: SwitchStyle.material, // Soft UI appearance
 ///   onChanged: (value) => _updateState(value),
 /// )
 /// ```
@@ -218,12 +217,6 @@ enum SwitchStyle {
   /// - Smooth transitions and hover effects
   /// - Balanced between minimal and rich
   modern,
-
-  /// 🌊 **Neumorphism** - Soft UI design
-  /// - Inset/outset shadow effects
-  /// - Soft, tactile appearance
-  /// - Perfect for premium interfaces
-  neumorphism,
 
   /// 💎 **Glassmorphism** - Glass-like transparency
   /// - Semi-transparent backgrounds


### PR DESCRIPTION
## 📋 PR Description

This PR removes the `neumorphism` visual style from the `OsmeaSwitch` component and its related enums. The decision to remove this style was based on:

- Redundancy with other visual styles (e.g., `glassmorphism`, `modern`)
- Accessibility concerns (low contrast, poor focus state support)
- Inconsistency with the design system’s direction
- Low usage and demand across supported platforms

### 🧹 Changes

| File / Enum Affected               | Description                                             
|-----------------------------------|---------------------------------------------------------|
| `SwitchStyle` enum                | ❌ Removed `SwitchStyle.neumorphism` variant            | `osmea_switch.dart`              | 🔧 Removed handling for `neumorphism` visual logic      
| `documentation & comments`        | 🧽 Cleaned up examples, doc blocks, and tooltips        
| `tests (if any)`                  | ✅ Updated tests to exclude deprecated style            


### 🚫 Removed

```dart
/// ❌ Deprecated
SwitchStyle.neumorphism

---

## ✅ Checklist

- [x] Code follows the project standards and guidelines.
- [ ] Relevant unit tests are written and all tests are passing.
- [ ] Test coverage is adequate for the changes.
- [x] Any unnecessary files or debug statements have been removed.
- [ ] Documentation is updated where necessary.
- [x] The PR has been reviewed by at least one team member before merging.

