### PR TITLE
OSMEA - Components -> TextField 

### DIFF
--- a/packages/components/example_mobile/lib/main.dart
+++ b/packages/components/example_mobile/lib/main.dart
@@ -7,6 +7,7 @@ import 'package:osmea_components_example/appbars_demo.dart';
 import 'package:osmea_components_example/switch_button_example.dart';
 import 'package:osmea_components_example/radio_button_example.dart';
 import 'package:osmea_components_example/text_example.dart';
+import 'package:osmea_components_example/text_field_example.dart';
 import 'package:osmea_components_example/colors_example.dart';
 import 'package:osmea_components_example/button_example.dart';
 import 'package:osmea_components_example/checkbox_example.dart';
@@ -239,6 +240,17 @@ class ComponentsScreen extends StatelessWidget {
                     context,
                     MaterialPageRoute(
                       builder: (context) => const TextExample(),
+                    ),
+                  ),
+                ),
+                _buildComponentCard(
+                  context,
+                  'Text Fields',
+                  Icons.input,
+                  () => Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (context) => const TextFieldExample(),
                     ),
                   ),
                 ),

--- a/packages/components/example_mobile/lib/text_field_example.dart
+++ b/packages/components/example_mobile/lib/text_field_example.dart
@@ -1,0 +1,544 @@
+import 'package:flutter/material.dart';
+import 'package:osmea_components/osmea_components.dart';
+
+/// 🔤 **OSMEA TextField Examples**
+///
+/// Comprehensive examples demonstrating all variants, sizes, and features
+/// of the OSMEA TextField component library including OTP TextField.
+///
+/// This file showcases:
+/// * 🎨 All text field variants (outlined, filled, underlined, borderless)
+/// * 📏 All size options (extraSmall, small, medium, large, extraLarge)
+/// * 🎭 All input types (text, email, password, number, etc.)
+/// * 🎯 Advanced features (floating labels, validation, custom builders)
+/// * 🔢 OTP TextField with different digit counts
+/// * 🎨 Custom styling and theming options
+/// * 🔧 Responsive layouts and accessibility features
+
+class TextFieldExample extends StatefulWidget {
+  const TextFieldExample({super.key});
+
+  @override
+  State<TextFieldExample> createState() => _TextFieldExampleState();
+}
+
+class _TextFieldExampleState extends State<TextFieldExample> {
+  // Controllers for different text fields
+  final TextEditingController _emailController = TextEditingController();
+  final TextEditingController _passwordController = TextEditingController();
+  final TextEditingController _nameController = TextEditingController();
+  final TextEditingController _phoneController = TextEditingController();
+  final TextEditingController _messageController = TextEditingController();
+
+  // State variables
+  bool _isPasswordVisible = false;
+  String _validationMessage = '';
+  bool _showFloatingLabel = true;
+  TextFieldVariant _selectedVariant = TextFieldVariant.outlined;
+  TextFieldSize _selectedSize = TextFieldSize.medium;
+
+  @override
+  void dispose() {
+    _emailController.dispose();
+    _passwordController.dispose();
+    _nameController.dispose();
+    _phoneController.dispose();
+    _messageController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return OsmeaComponents.scaffold(
+      appBar: AppBar(
+        title: OsmeaComponents.text(
+          '🔤 OSMEA TextField Examples',
+          variant: OsmeaTextVariant.headlineMedium,
+        ),
+        backgroundColor: OsmeaColors.nordicBlue,
+        foregroundColor: OsmeaColors.white,
+      ),
+      body: SingleChildScrollView(
+        padding: context.paddingNormal,
+        child: OsmeaComponents.column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _buildSectionTitle('🎨 TextField Variants'),
+            _buildVariantsSection(),
+            OsmeaComponents.sizedBox(height: 32),
+            _buildSectionTitle('📏 TextField Sizes'),
+            _buildSizesSection(),
+            OsmeaComponents.sizedBox(height: 32),
+            _buildSectionTitle('🎭 Input Types & Validation'),
+            _buildInputTypesSection(),
+            OsmeaComponents.sizedBox(height: 32),
+            _buildSectionTitle('🎯 Advanced Features'),
+            _buildAdvancedFeaturesSection(),
+            OsmeaComponents.sizedBox(height: 32),
+            _buildSectionTitle('🔢 OTP TextField Examples'),
+            _buildOTPSection(),
+            OsmeaComponents.sizedBox(height: 32),
+            _buildSectionTitle('⚙️ Interactive Demo'),
+            _buildInteractiveDemoSection(),
+            OsmeaComponents.sizedBox(height: 32),
+            _buildSectionTitle('🎨 Custom Styling'),
+            _buildCustomStylingSection(),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSectionTitle(String title) {
+    return Padding(
+      padding: EdgeInsets.only(bottom: context.spacing16),
+      child: OsmeaComponents.text(
+        title,
+        variant: OsmeaTextVariant.headlineSmall,
+        color: OsmeaColors.slate,
+      ),
+    );
+  }
+
+  Widget _buildVariantsSection() {
+    return OsmeaComponents.column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        // Outlined TextField
+        OsmeaComponents.textField(
+          label: 'Outlined TextField',
+          hint: 'Enter text here...',
+          variant: TextFieldVariant.outlined,
+          size: TextFieldSize.medium,
+          prefixIcon: const Icon(Icons.person_outline),
+        ),
+        OsmeaComponents.sizedBox(height: 16),
+
+        // Filled TextField
+        OsmeaComponents.textField(
+          label: 'Filled TextField',
+          hint: 'Enter text here...',
+          variant: TextFieldVariant.filled,
+          size: TextFieldSize.medium,
+          prefixIcon: const Icon(Icons.email_outlined),
+        ),
+        OsmeaComponents.sizedBox(height: 16),
+
+        // Underlined TextField
+        OsmeaComponents.textField(
+          label: 'Underlined TextField',
+          hint: 'Enter text here...',
+          variant: TextFieldVariant.underlined,
+          size: TextFieldSize.medium,
+          prefixIcon: const Icon(Icons.phone_outlined),
+        ),
+        OsmeaComponents.sizedBox(height: 16),
+
+        // Borderless TextField
+        OsmeaComponents.textField(
+          label: 'Borderless TextField',
+          hint: 'Enter text here...',
+          variant: TextFieldVariant.borderless,
+          size: TextFieldSize.medium,
+          prefixIcon: const Icon(Icons.search_outlined),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildSizesSection() {
+    final sizes = [
+      {'size': TextFieldSize.extraSmall, 'name': 'Extra Small'},
+      {'size': TextFieldSize.small, 'name': 'Small'},
+      {'size': TextFieldSize.medium, 'name': 'Medium'},
+      {'size': TextFieldSize.large, 'name': 'Large'},
+      {'size': TextFieldSize.extraLarge, 'name': 'Extra Large'},
+    ];
+
+    return OsmeaComponents.column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: sizes.map((sizeData) {
+        return Padding(
+          padding: EdgeInsets.only(bottom: context.spacing12),
+          child: OsmeaComponents.textField(
+            label: sizeData['name'] as String,
+            hint: 'Size: ${sizeData['name']}',
+            variant: TextFieldVariant.outlined,
+            size: sizeData['size'] as TextFieldSize,
+            prefixIcon: const Icon(Icons.format_size),
+          ),
+        );
+      }).toList(),
+    );
+  }
+
+  Widget _buildInputTypesSection() {
+    return OsmeaComponents.column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        // Email TextField
+        OsmeaComponents.textField(
+          controller: _emailController,
+          label: 'Email Address',
+          hint: 'Enter your email',
+          type: TextFieldType.email,
+          variant: TextFieldVariant.outlined,
+          size: TextFieldSize.medium,
+          prefixIcon: const Icon(Icons.email_outlined),
+          validator: (value) {
+            if (value == null || value.isEmpty) {
+              return 'Email is required';
+            }
+            if (!RegExp(r'^[\w-\.]+@([\w-]+\.)+[\w-]{2,4}$').hasMatch(value)) {
+              return 'Please enter a valid email';
+            }
+            return null;
+          },
+          onChanged: (value) => setState(() {}),
+        ),
+        OsmeaComponents.sizedBox(height: 16),
+
+        // Password TextField
+        OsmeaComponents.textField(
+          controller: _passwordController,
+          label: 'Password',
+          hint: 'Enter your password',
+          type: TextFieldType.password,
+          variant: TextFieldVariant.outlined,
+          size: TextFieldSize.medium,
+          obscureText: !_isPasswordVisible,
+          prefixIcon: const Icon(Icons.lock_outline),
+          suffixIcon: IconButton(
+            icon: Icon(
+                _isPasswordVisible ? Icons.visibility_off : Icons.visibility),
+            onPressed: () =>
+                setState(() => _isPasswordVisible = !_isPasswordVisible),
+          ),
+          validator: (value) {
+            if (value == null || value.isEmpty) {
+              return 'Password is required';
+            }
+            if (value.length < 6) {
+              return 'Password must be at least 6 characters';
+            }
+            return null;
+          },
+        ),
+        OsmeaComponents.sizedBox(height: 16),
+
+        // Phone Number TextField
+        OsmeaComponents.textField(
+          controller: _phoneController,
+          label: 'Phone Number',
+          hint: '+1 (555) 123-4567',
+          type: TextFieldType.phone,
+          variant: TextFieldVariant.outlined,
+          size: TextFieldSize.medium,
+          prefixIcon: const Icon(Icons.phone_outlined),
+          maxLength: 15,
+        ),
+        OsmeaComponents.sizedBox(height: 16),
+
+        // Multiline TextField
+        OsmeaComponents.textField(
+          controller: _messageController,
+          label: 'Message',
+          hint: 'Enter your message here...',
+          type: TextFieldType.multiline,
+          variant: TextFieldVariant.outlined,
+          size: TextFieldSize.medium,
+          prefixIcon: const Icon(Icons.message_outlined),
+          maxLines: 4,
+          minLines: 2,
+          maxLength: 500,
+        ),
+      ],
+    );
+  }
+
+  Widget _buildAdvancedFeaturesSection() {
+    return OsmeaComponents.column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        // Floating Label TextField
+        OsmeaComponents.textField(
+          label: 'Floating Label TextField',
+          hint: 'Watch the label float...',
+          variant: TextFieldVariant.outlined,
+          size: TextFieldSize.medium,
+          prefixIcon: const Icon(Icons.label_outline),
+          helperText: 'The label will float above when focused or filled',
+        ),
+        OsmeaComponents.sizedBox(height: 16),
+
+        // Custom Error Builder TextField
+        OsmeaComponents.textField(
+          label: 'Custom Error Display',
+          hint: 'Enter "error" to see custom error',
+          variant: TextFieldVariant.outlined,
+          size: TextFieldSize.medium,
+          prefixIcon: const Icon(Icons.error_outline),
+          validator: (value) =>
+              value == 'error' ? 'This is a custom error message' : null,
+          onChanged: (value) => setState(() {}),
+        ),
+        OsmeaComponents.sizedBox(height: 16),
+
+        // Disabled TextField
+        OsmeaComponents.textField(
+          label: 'Disabled TextField',
+          hint: 'This field is disabled',
+          variant: TextFieldVariant.outlined,
+          size: TextFieldSize.medium,
+          enabled: false,
+          prefixIcon: const Icon(Icons.block),
+          helperText: 'This field cannot be edited',
+        ),
+      ],
+    );
+  }
+
+  Widget _buildOTPSection() {
+    return OsmeaComponents.column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        // 4-digit OTP
+        OsmeaComponents.text(
+          '4-Digit OTP',
+          variant: OsmeaTextVariant.titleMedium,
+          color: OsmeaColors.slate,
+        ),
+        OsmeaComponents.sizedBox(height: 8),
+        OsmeaComponents.otpTextField(
+          digitCount: 4,
+          size: TextFieldSize.large,
+          variant: TextFieldVariant.outlined,
+          spacing: 12.0,
+          onChanged: (otp) => print('4-digit OTP changed: $otp'),
+          onCompleted: (otp) {
+            print('4-digit OTP completed: $otp');
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(content: Text('4-digit OTP completed: $otp')),
+            );
+          },
+          validator: (otp) => otp?.length == 4 ? null : 'Please enter 4 digits',
+        ),
+        OsmeaComponents.sizedBox(height: 24),
+
+        // 6-digit OTP
+        OsmeaComponents.text(
+          '6-Digit OTP (Default)',
+          variant: OsmeaTextVariant.titleMedium,
+          color: OsmeaColors.slate,
+        ),
+        OsmeaComponents.sizedBox(height: 8),
+        OsmeaComponents.otpTextField(
+          digitCount: 6,
+          size: TextFieldSize.medium,
+          variant: TextFieldVariant.filled,
+          spacing: 8.0,
+          onChanged: (otp) {
+            print('6-digit OTP changed: $otp');
+          },
+          onCompleted: (otp) {
+            print('6-digit OTP completed: $otp');
+            setState(() => _validationMessage = 'OTP Completed: $otp');
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(
+                content: Text('6-digit OTP completed: $otp'),
+                backgroundColor: OsmeaColors.forestHeart,
+              ),
+            );
+          },
+          validator: (otp) {
+            if (otp == null || otp.isEmpty) return 'OTP is required';
+            if (otp.length < 6) return 'Please enter all 6 digits';
+            return null;
+          },
+        ),
+        if (_validationMessage.isNotEmpty) ...[
+          OsmeaComponents.sizedBox(height: 8),
+          Container(
+            padding: EdgeInsets.all(context.spacing12),
+            decoration: BoxDecoration(
+              color: OsmeaColors.forestHeart.withOpacity(0.1),
+              borderRadius: BorderRadius.circular(8),
+              border: Border.all(color: OsmeaColors.forestHeart, width: 1),
+            ),
+            child: Row(
+              children: [
+                Icon(Icons.check_circle,
+                    color: OsmeaColors.forestHeart, size: 16),
+                SizedBox(width: context.spacing8),
+                Text(
+                  _validationMessage,
+                  style:
+                      TextStyle(color: OsmeaColors.forestHeart, fontSize: 12),
+                ),
+              ],
+            ),
+          ),
+        ],
+        OsmeaComponents.sizedBox(height: 24),
+
+        // 5-digit OTP with custom styling
+        OsmeaComponents.text(
+          '5-Digit OTP (Custom Style)',
+          variant: OsmeaTextVariant.titleMedium,
+          color: OsmeaColors.slate,
+        ),
+        OsmeaComponents.sizedBox(height: 8),
+        OsmeaComponents.otpTextField(
+          digitCount: 5,
+          size: TextFieldSize.large,
+          variant: TextFieldVariant.underlined,
+          spacing: 16.0,
+          obscureText: true, // Hidden digits for security
+          backgroundColor: OsmeaColors.nordicBlue.withOpacity(0.05),
+          focusColor: OsmeaColors.nordicBlue,
+          borderColor: OsmeaColors.silver,
+          onChanged: (otp) =>
+              print('5-digit secure OTP changed: ${'*' * otp.length}'),
+          onCompleted: (otp) {
+            print('5-digit secure OTP completed');
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(
+                content: const Text('Secure OTP completed!'),
+                backgroundColor: OsmeaColors.nordicBlue,
+              ),
+            );
+          },
+        ),
+      ],
+    );
+  }
+
+  Widget _buildInteractiveDemoSection() {
+    return Container(
+      padding: EdgeInsets.all(context.spacing16),
+      decoration: BoxDecoration(
+        color: OsmeaColors.pewter.withOpacity(0.05),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: OsmeaColors.silver, width: 1),
+      ),
+      child: OsmeaComponents.column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          OsmeaComponents.text(
+            'Interactive TextField Demo',
+            variant: OsmeaTextVariant.titleMedium,
+            color: OsmeaColors.slate,
+          ),
+          OsmeaComponents.sizedBox(height: 16),
+
+          // Variant Selection
+          OsmeaComponents.text(
+            'Variant:',
+            variant: OsmeaTextVariant.bodyMedium,
+            color: OsmeaColors.slate,
+          ),
+          OsmeaComponents.sizedBox(height: 8),
+          Wrap(
+            spacing: 8,
+            children: TextFieldVariant.values.map((variant) {
+              return ChoiceChip(
+                label: Text(variant.toString().split('.').last),
+                selected: _selectedVariant == variant,
+                onSelected: (selected) =>
+                    setState(() => _selectedVariant = variant),
+              );
+            }).toList(),
+          ),
+          OsmeaComponents.sizedBox(height: 16),
+
+          // Size Selection
+          OsmeaComponents.text(
+            'Size:',
+            variant: OsmeaTextVariant.bodyMedium,
+            color: OsmeaColors.slate,
+          ),
+          OsmeaComponents.sizedBox(height: 8),
+          Wrap(
+            spacing: 8,
+            children: TextFieldSize.values.map((size) {
+              return ChoiceChip(
+                label: Text(size.toString().split('.').last),
+                selected: _selectedSize == size,
+                onSelected: (selected) => setState(() => _selectedSize = size),
+              );
+            }).toList(),
+          ),
+          OsmeaComponents.sizedBox(height: 16),
+
+          // Floating Label Toggle
+          CheckboxListTile(
+            title: const Text('Floating Label'),
+            value: _showFloatingLabel,
+            onChanged: (value) =>
+                setState(() => _showFloatingLabel = value ?? false),
+            contentPadding: EdgeInsets.zero,
+          ),
+          OsmeaComponents.sizedBox(height: 16),
+
+          // Demo TextField
+          OsmeaComponents.textField(
+            label: 'Interactive Demo TextField',
+            hint: 'This field changes based on your selections above',
+            variant: _selectedVariant,
+            size: _selectedSize,
+            prefixIcon: const Icon(Icons.settings),
+            helperText:
+                'Variant: ${_selectedVariant.toString().split('.').last}, Size: ${_selectedSize.toString().split('.').last}',
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildCustomStylingSection() {
+    return OsmeaComponents.column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        // Custom colored TextField
+        OsmeaComponents.textField(
+          label: 'Custom Themed TextField',
+          hint: 'This field has custom colors',
+          variant: TextFieldVariant.outlined,
+          size: TextFieldSize.medium,
+          backgroundColor: OsmeaColors.nordicBlue.withOpacity(0.05),
+          borderColor: OsmeaColors.nordicBlue,
+          focusColor: OsmeaColors.forestHeart,
+          textColor: OsmeaColors.slate,
+          labelColor: OsmeaColors.nordicBlue,
+          hintColor: OsmeaColors.pewter,
+          prefixIcon: Icon(Icons.palette, color: OsmeaColors.nordicBlue),
+          helperText: 'Custom colors applied to this field',
+        ),
+        OsmeaComponents.sizedBox(height: 16),
+
+        // Full-width TextField
+        OsmeaComponents.textField(
+          label: 'Full Width TextField',
+          hint: 'This field takes full width',
+          variant: TextFieldVariant.filled,
+          size: TextFieldSize.large,
+          fullWidth: true,
+          prefixIcon: const Icon(Icons.fullscreen),
+          helperText: 'This field spans the full width of its container',
+        ),
+        OsmeaComponents.sizedBox(height: 16),
+
+        // Custom animation duration
+        OsmeaComponents.textField(
+          label: 'Slow Animation TextField',
+          hint: 'Watch the slow transition animations',
+          variant: TextFieldVariant.outlined,
+          size: TextFieldSize.medium,
+          animationDuration: const Duration(milliseconds: 800),
+          prefixIcon: const Icon(Icons.slow_motion_video),
+          helperText: 'This field has slower transition animations',
+        ),
+      ],
+    );
+  }
+}

--- a/packages/components/lib/osmea_components.dart
+++ b/packages/components/lib/osmea_components.dart
@@ -21,12 +21,22 @@ export 'src/components/radio_button/radio_button.dart';
 // 🔑 Login Button
 export 'src/components/login_button/login_button.dart';
 
+// 🔤 Text Field
+
+export 'src/components/text_field/cubit/otp_cubit.dart';
+export 'src/components/text_field/cubit/otp_state.dart';
+export 'src/components/text_field/cubit/text_field_cubit.dart';
+export 'src/components/text_field/cubit/text_field_state.dart';
+export 'src/components/text_field/controllers/text_field_controller.dart';
+export 'src/utils/text_field_size_extensions.dart';
+
 // 🛠️ Utils
 // Utility functions and extensions
 export 'src/utils/sizer_extensions.dart';
 export 'src/utils/text_extensions.dart';
 export 'src/utils/button_size_extensions.dart';
 export 'src/utils/button_shape_extensions.dart';
+
 export 'src/utils/icon_positions_extensions.dart';
 export 'src/utils/switch_size_extensions.dart';
 export 'src/utils/navbar_extensions.dart';

--- a/packages/components/lib/src/components.dart
+++ b/packages/components/lib/src/components.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter/gestures.dart';
 
 // Component imports
@@ -20,6 +21,9 @@ import 'package:osmea_components/src/components/single_child_scroll_view/single_
 import 'package:osmea_components/src/components/sized_box/sized_box.dart';
 import 'package:osmea_components/src/components/switch_button/switch_button.dart';
 import 'package:osmea_components/src/components/radio_button/radio_button.dart';
+import 'package:osmea_components/src/components/text_field/text_field.dart';
+import 'package:osmea_components/src/components/text_field/otp_text_field.dart';
+import 'package:osmea_components/src/components/text_field/controllers/text_field_controller.dart';
 import 'package:osmea_components/src/components/wrap/wrap.dart';
 import 'package:osmea_components/src/theme/theme.dart';
 import 'package:osmea_components/src/components/text/text.dart';
@@ -1190,6 +1194,201 @@ class OsmeaComponents {
     );
   }
 
+  /// 🔤 **OSMEA TextField** - Comprehensive text input component
+  ///
+  /// Creates a fully-featured text input field with support for:
+  /// - Multiple variants (outlined, filled, underlined, borderless)
+  /// - Size options (extraSmall to extraLarge)
+  /// - Input types (text, email, password, number, etc.)
+  /// - Built-in validation support
+  /// - Custom styling capabilities
+  /// - Responsive design
+  ///
+  /// Example:
+  /// ```dart
+  /// OsmeaComponents.textField(
+  ///   label: 'Email Address',
+  ///   hint: 'Enter your email',
+  ///   type: TextFieldType.email,
+  ///   variant: TextFieldVariant.outlined,
+  ///   size: TextFieldSize.medium,
+  ///   onChanged: (value) => handleEmailChange(value),
+  /// )
+  /// ```
+  static Widget textField({
+    Key? key,
+    CoreTheme? customTheme,
+    TextEditingController? controller,
+    OsmeaTextFieldController? osmeaController,
+    FocusNode? focusNode,
+    String? label,
+    String? hint,
+    String? helperText,
+    String? errorText,
+    Widget? prefixIcon,
+    Widget? suffixIcon,
+    TextFieldSize size = TextFieldSize.medium,
+    TextFieldVariant variant = TextFieldVariant.outlined,
+    TextFieldState state = TextFieldState.enabled,
+    TextFieldType type = TextFieldType.text,
+    bool isRequired = false,
+    String? Function(String?)? validator,
+    ValueChanged<String>? onChanged,
+    ValueChanged<String>? onSubmitted,
+    GestureTapCallback? onTap,
+    VoidCallback? onEditingComplete,
+    int? maxLines = 1,
+    int? minLines,
+    int? maxLength,
+    bool obscureText = false,
+    bool readOnly = false,
+    bool autofocus = false,
+    bool? enabled,
+    TextAlign textAlign = TextAlign.start,
+    TextCapitalization textCapitalization = TextCapitalization.none,
+    TextInputType? keyboardType,
+    TextInputAction? textInputAction,
+    List<TextInputFormatter>? inputFormatters,
+    TextStyle? textStyle,
+    Color? textColor,
+    Color? backgroundColor,
+    Color? borderColor,
+    Color? focusColor,
+    Color? errorColor,
+    Color? hintColor,
+    Color? labelColor,
+    bool fullWidth = false,
+    Duration? animationDuration,
+  }) {
+    return OsmeaTextField(
+      key: key,
+      customTheme: customTheme,
+      controller: controller,
+      osmeaController: osmeaController,
+      focusNode: focusNode,
+      label: label,
+      hint: hint,
+      helperText: helperText,
+      errorText: errorText,
+      prefixIcon: prefixIcon,
+      suffixIcon: suffixIcon,
+      size: size,
+      variant: variant,
+      state: state,
+      type: type,
+      isRequired: isRequired,
+      validator: validator,
+      onChanged: onChanged,
+      onSubmitted: onSubmitted,
+      onTap: onTap,
+      onEditingComplete: onEditingComplete,
+      maxLines: maxLines,
+      minLines: minLines,
+      maxLength: maxLength,
+      obscureText: obscureText,
+      readOnly: readOnly,
+      autofocus: autofocus,
+      enabled: enabled,
+      textAlign: textAlign,
+      textCapitalization: textCapitalization,
+      keyboardType: keyboardType,
+      textInputAction: textInputAction,
+      inputFormatters: inputFormatters,
+      textStyle: textStyle,
+      textColor: textColor,
+      backgroundColor: backgroundColor,
+      borderColor: borderColor,
+      focusColor: focusColor,
+      errorColor: errorColor,
+      hintColor: hintColor,
+      labelColor: labelColor,
+      fullWidth: fullWidth,
+      animationDuration: animationDuration,
+    );
+  }
+
+  /// 🔢 **OSMEA OTP TextField** - One-Time Password input component
+  ///
+  /// Creates a specialized input for OTP codes with:
+  /// - Individual digit fields with auto-navigation
+  /// - Configurable digit count (4, 5, 6, etc.)
+  /// - Copy-paste support
+  /// - Custom styling options
+  /// - Validation support
+  /// - Responsive design
+  /// - Stateless architecture for better performance
+  ///
+  /// **Features:**
+  /// - Auto-focus navigation between fields
+  /// - Backspace handling for previous field
+  /// - Numeric keyboard input
+  /// - Obscure text option for security
+  /// - Custom spacing and styling
+  /// - Real-time validation feedback
+  /// - Accessibility support
+  ///
+  /// **Usage Examples:**
+  /// ```dart
+  /// // Basic 6-digit OTP
+  /// OsmeaComponents.otpTextField(
+  ///   digitCount: 6,
+  ///   onCompleted: (otp) => _verifyOTP(otp),
+  ///   onChanged: (otp) => _updateUI(otp),
+  /// )
+  ///
+  /// // Secure OTP with validation
+  /// OsmeaComponents.otpTextField(
+  ///   digitCount: 4,
+  ///   obscureText: true,
+  ///   variant: TextFieldVariant.filled,
+  ///   validator: (otp) => otp?.length == 4 ? null : 'Invalid OTP',
+  ///   onCompleted: (otp) => _processSecureOTP(otp),
+  /// )
+  /// ```
+  static Widget otpTextField({
+    Key? key,
+    int digitCount = 6,
+    TextFieldSize size = TextFieldSize.medium,
+    TextFieldVariant variant = TextFieldVariant.outlined,
+    double spacing = 8.0,
+    ValueChanged<String>? onChanged,
+    ValueChanged<String>? onCompleted,
+    String? Function(String?)? validator,
+    bool autoFocus = true,
+    bool obscureText = false,
+    bool enabled = true,
+    bool showCursor = true,
+    Color? backgroundColor,
+    Color? borderColor,
+    Color? focusColor,
+    Color? errorColor,
+    Color? textColor,
+    Duration? animationDuration,
+    BoxDecoration? pinInputDecoration,
+  }) {
+    return OsmeaOTPTextField(
+      key: key,
+      digitCount: digitCount,
+      size: size,
+      variant: variant,
+      spacing: spacing,
+      onOTPChanged: onChanged,
+      onOTPCompleted: onCompleted,
+      otpValidator: validator,
+      autoFocus: autoFocus,
+      obscureText: obscureText,
+      enabled: enabled,
+      showCursor: showCursor,
+      backgroundColor: backgroundColor,
+      borderColor: borderColor,
+      focusColor: focusColor,
+      errorColor: errorColor,
+      textColor: textColor,
+      animationDuration: animationDuration,
+      pinInputDecoration: pinInputDecoration,
+    );
+  }
+
   /// 📜 **OSMEA SingleChildScrollView** - Scrollable content wrapper
   ///
   /// Creates a scrollable widget that can contain a single child.
@@ -1231,7 +1430,6 @@ class OsmeaComponents {
       child: child,
     );
   }
-
 }
 
 /// 🎯 **OSMEA AppBar Action** - Action button configuration

--- a/packages/components/lib/src/components/text_field/controllers/otp_field_controller.dart
+++ b/packages/components/lib/src/components/text_field/controllers/otp_field_controller.dart
@@ -1,0 +1,26 @@
+class OTPController {
+  /// Validate OTP format
+  static String? validateOTP(String? otp, int expectedLength) {
+    if (otp == null || otp.isEmpty) {
+      return 'OTP is required';
+    }
+    if (otp.length != expectedLength) {
+      return 'OTP must be $expectedLength digits';
+    }
+    if (!RegExp(r'^\d+$').hasMatch(otp)) {
+      return 'OTP must contain only numbers';
+    }
+    return null;
+  }
+
+  /// Format OTP for display
+  static String formatOTP(String otp, {String separator = '-'}) {
+    if (otp.length <= 4) return otp;
+    return otp.split('').join(separator);
+  }
+
+  /// Clean OTP string (remove non-digits)
+  static String cleanOTP(String input) {
+    return input.replaceAll(RegExp(r'[^\d]'), '');
+  }
+}

--- a/packages/components/lib/src/components/text_field/controllers/text_field_controller.dart
+++ b/packages/components/lib/src/components/text_field/controllers/text_field_controller.dart
@@ -1,0 +1,112 @@
+import 'package:flutter/material.dart';
+import 'package:osmea_components/src/enums/components_enum.dart';
+
+/// 🎮 **OSMEA TextField Controller**
+///
+/// Enhanced TextEditingController with additional features for OSMEA text fields.
+/// Provides built-in validation, formatting, and state management.
+///
+/// **Features:**
+/// - Type-aware validation
+/// - Automatic text formatting
+/// - Error state management
+/// - Value change notifications
+///
+/// **Usage:**
+/// ```dart
+/// final controller = OsmeaTextFieldController(
+///   type: TextFieldType.email,
+///   validator: (value) => value?.contains('@') == true ? null : 'Invalid email',
+/// );
+///
+/// OsmeaComponents.textField(
+///   controller: controller,
+///   label: 'Email',
+/// )
+/// ```
+
+class OsmeaTextFieldController extends TextEditingController {
+  OsmeaTextFieldController({
+    String? text,
+    this.type = TextFieldType.text,
+    this.validator,
+    this.minLength,
+    this.maxLength,
+  }) : super(text: text);
+
+  /// Type of text field this controller manages
+  final TextFieldType type;
+
+  /// Validation function for input text
+  final String? Function(String?)? validator;
+
+  /// Minimum length for the text field
+  final int? minLength;
+
+  /// Maximum length for the text field
+  final int? maxLength;
+
+  /// Current validation error message
+  String? _errorMessage;
+
+  /// Get current error message
+  String? get errorMessage => _errorMessage;
+
+  /// Whether the current value is valid
+  bool get isValid => validate() == null;
+
+  /// Whether the field has any error
+  bool get hasError => _errorMessage != null;
+
+  /// Validates the current text and returns error message if invalid
+  String? validate() {
+    final currentText = text;
+
+    // Check length constraints first
+    if (minLength != null && currentText.length < minLength!) {
+      _errorMessage = 'Must be at least $minLength characters';
+      notifyListeners();
+      return _errorMessage;
+    }
+
+    if (maxLength != null && currentText.length > maxLength!) {
+      _errorMessage = 'Cannot exceed $maxLength characters';
+      notifyListeners();
+      return _errorMessage;
+    }
+
+    // Apply custom validator
+    _errorMessage = validator?.call(currentText);
+    notifyListeners();
+    return _errorMessage;
+  }
+
+  /// Clears any existing error message
+  void clearError() {
+    if (_errorMessage != null) {
+      _errorMessage = null;
+      notifyListeners();
+    }
+  }
+
+  /// Sets a custom error message
+  void setError(String errorMessage) {
+    _errorMessage = errorMessage;
+    notifyListeners();
+  }
+
+  /// Validates and sets text, returning whether validation passed
+  bool setTextWithValidation(String newText) {
+    text = newText;
+    return validate() == null;
+  }
+
+  @override
+  set text(String newText) {
+    super.text = newText;
+    // Clear error when text changes
+    if (_errorMessage != null) {
+      clearError();
+    }
+  }
+}

--- a/packages/components/lib/src/components/text_field/cubit/otp_cubit.dart
+++ b/packages/components/lib/src/components/text_field/cubit/otp_cubit.dart
@@ -1,0 +1,258 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:osmea_components/src/components/text_field/cubit/otp_state.dart';
+import 'dart:async';
+
+/// OTP Cubit for managing OTP state
+class OTPCubit extends Cubit<OTPState> {
+  final int digitCount;
+  final String? Function(String?)? validator;
+  final ValueChanged<String>? onChanged;
+  final ValueChanged<String>? onCompleted;
+
+  late List<TextEditingController> _controllers;
+  late List<FocusNode> _focusNodes;
+
+  // Backspace handling
+  Timer? _backspaceTimer;
+  bool _isBackspacePressed = false;
+
+  OTPCubit({
+    required this.digitCount,
+    this.validator,
+    this.onChanged,
+    this.onCompleted,
+  }) : super(OTPState(digits: List.filled(digitCount, ''))) {
+    _initializeControllers();
+  }
+
+  /// Get controllers for external use
+  List<TextEditingController> get controllers => _controllers;
+
+  /// Get focus nodes for external use
+  List<FocusNode> get focusNodes => _focusNodes;
+
+  void _initializeControllers() {
+    _controllers = List.generate(
+      digitCount,
+      (index) => TextEditingController(),
+    );
+    _focusNodes = List.generate(
+      digitCount,
+      (index) => FocusNode(),
+    );
+
+    // Add listeners to controllers
+    for (int i = 0; i < _controllers.length; i++) {
+      _controllers[i].addListener(() => _handleControllerChange(i));
+    }
+  }
+
+  /// Handle digit input change
+  void onDigitChanged(int index, String value) {
+    if (index < 0 || index >= digitCount) return;
+
+    final newDigits = List<String>.from(state.digits);
+    newDigits[index] = value;
+
+    // Auto-focus next field if value is entered
+    if (value.isNotEmpty && index < digitCount - 1) {
+      _focusNodes[index + 1].requestFocus();
+    }
+
+    _updateState(newDigits, index);
+  }
+
+  /// Handle backspace key press
+  void onBackspace(int index) {
+    if (index < 0 || index >= digitCount) return;
+
+    final newDigits = List<String>.from(state.digits);
+
+    // Clear current field
+    newDigits[index] = '';
+    _controllers[index].clear();
+
+    // Move to previous field if current is empty
+    if (index > 0) {
+      _focusNodes[index - 1].requestFocus();
+      // Also clear the previous field
+      newDigits[index - 1] = '';
+      _controllers[index - 1].clear();
+    }
+
+    _updateState(newDigits, index > 0 ? index - 1 : 0);
+  }
+
+  /// Handle controller changes (for paste operations and other inputs)
+  void _handleControllerChange(int index) {
+    final currentValue = _controllers[index].text;
+
+    // Handle paste operation (multiple characters)
+    if (currentValue.length > 1) {
+      _handlePasteOperation(currentValue, index);
+      return;
+    }
+
+    // Handle single character input
+    if (currentValue.isNotEmpty) {
+      onDigitChanged(index, currentValue);
+    }
+  }
+
+  /// Handle paste operation
+  void _handlePasteOperation(String pastedValue, int startIndex) {
+    final digits = pastedValue.replaceAll(RegExp(r'[^\d]'), '');
+    final newDigits = List<String>.from(state.digits);
+
+    for (int i = 0; i < digits.length && (startIndex + i) < digitCount; i++) {
+      newDigits[startIndex + i] = digits[i];
+      _controllers[startIndex + i].text = digits[i];
+    }
+
+    // Focus last filled field or complete field
+    final lastFilledIndex =
+        (startIndex + digits.length - 1).clamp(0, digitCount - 1);
+    if (lastFilledIndex < digitCount - 1) {
+      _focusNodes[lastFilledIndex + 1].requestFocus();
+    } else {
+      _focusNodes[lastFilledIndex].unfocus();
+    }
+
+    _updateState(newDigits, lastFilledIndex);
+  }
+
+  /// Update state with new digits
+  void _updateState(List<String> newDigits, int currentIndex) {
+    final otpValue = newDigits.join();
+    final isCompleted = newDigits.every((digit) => digit.isNotEmpty);
+    final error = validator?.call(otpValue);
+
+    emit(state.copyWith(
+      digits: newDigits,
+      currentIndex: currentIndex,
+      error: error,
+      isCompleted: isCompleted,
+    ));
+
+    // Trigger callbacks
+    onChanged?.call(otpValue);
+    if (isCompleted) {
+      onCompleted?.call(otpValue);
+    }
+  }
+
+  /// Clear all OTP fields
+  void clear() {
+    for (var controller in _controllers) {
+      controller.clear();
+    }
+
+    emit(OTPState(digits: List.filled(digitCount, '')));
+    onChanged?.call('');
+
+    // Focus first field
+    if (_focusNodes.isNotEmpty) {
+      Future.microtask(() => _focusNodes[0].requestFocus());
+    }
+  }
+
+  /// Set OTP value programmatically
+  void setOTP(String otp) {
+    final digits = otp.split('').take(digitCount).toList();
+    while (digits.length < digitCount) {
+      digits.add('');
+    }
+
+    for (int i = 0; i < digitCount; i++) {
+      _controllers[i].text = digits[i];
+    }
+
+    _updateState(digits, digits.lastIndexWhere((d) => d.isNotEmpty));
+  }
+
+  /// Validate current OTP
+  bool validate() {
+    final error = validator?.call(state.otpValue);
+    emit(state.copyWith(error: error));
+    return error == null;
+  }
+
+  /// Handle long press backspace (clear all)
+  void onLongPressBackspace() {
+    _clearAllFieldsWithAnimation();
+  }
+
+  /// Clear all fields with animation
+  void _clearAllFieldsWithAnimation() async {
+    for (int i = digitCount - 1; i >= 0; i--) {
+      if (_controllers[i].text.isNotEmpty) {
+        _controllers[i].clear();
+        await Future.delayed(const Duration(milliseconds: 80));
+      }
+    }
+
+    emit(OTPState(digits: List.filled(digitCount, '')));
+    onChanged?.call('');
+
+    // Focus first field
+    if (_focusNodes.isNotEmpty) {
+      Future.microtask(() => _focusNodes[0].requestFocus());
+    }
+
+    HapticFeedback.mediumImpact();
+  }
+
+  /// Handle key events
+  void onKeyEvent(KeyEvent event) {
+    if (event.logicalKey == LogicalKeyboardKey.backspace) {
+      if (event is KeyDownEvent) {
+        if (!_isBackspacePressed) {
+          _isBackspacePressed = true;
+          _backspaceTimer = Timer(const Duration(milliseconds: 800), () {
+            if (_isBackspacePressed) {
+              onLongPressBackspace();
+            }
+          });
+        }
+      } else if (event is KeyUpEvent) {
+        _isBackspacePressed = false;
+        _backspaceTimer?.cancel();
+        _backspaceTimer = null;
+      }
+    }
+  }
+
+  /// Focus specific field
+  void focusField(int index) {
+    if (index >= 0 && index < digitCount) {
+      _focusNodes[index].requestFocus();
+    }
+  }
+
+  /// Auto-focus first empty field
+  void autoFocus() {
+    final firstEmptyIndex = state.digits.indexWhere((digit) => digit.isEmpty);
+    if (firstEmptyIndex != -1) {
+      _focusNodes[firstEmptyIndex].requestFocus();
+    } else if (_focusNodes.isNotEmpty) {
+      _focusNodes[0].requestFocus();
+    }
+  }
+
+  @override
+  Future<void> close() {
+    _backspaceTimer?.cancel();
+
+    // Dispose controllers and focus nodes
+    for (var controller in _controllers) {
+      controller.dispose();
+    }
+    for (var focusNode in _focusNodes) {
+      focusNode.dispose();
+    }
+
+    return super.close();
+  }
+}

--- a/packages/components/lib/src/components/text_field/cubit/otp_state.dart
+++ b/packages/components/lib/src/components/text_field/cubit/otp_state.dart
@@ -1,0 +1,57 @@
+/// OTP State representation
+class OTPState {
+  final List<String> digits;
+  final int currentIndex;
+  final String? error;
+  final bool isCompleted;
+  final bool isLoading;
+
+  const OTPState({
+    required this.digits,
+    this.currentIndex = 0,
+    this.error,
+    this.isCompleted = false,
+    this.isLoading = false,
+  });
+
+  /// Get the complete OTP string
+  String get otpValue => digits.join();
+
+  /// Check if OTP has any digits
+  bool get hasValue => digits.any((digit) => digit.isNotEmpty);
+
+  OTPState copyWith({
+    List<String>? digits,
+    int? currentIndex,
+    String? error,
+    bool? isCompleted,
+    bool? isLoading,
+  }) {
+    return OTPState(
+      digits: digits ?? this.digits,
+      currentIndex: currentIndex ?? this.currentIndex,
+      error: error,
+      isCompleted: isCompleted ?? this.isCompleted,
+      isLoading: isLoading ?? this.isLoading,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is OTPState &&
+          runtimeType == other.runtimeType &&
+          digits.toString() == other.digits.toString() &&
+          currentIndex == other.currentIndex &&
+          error == other.error &&
+          isCompleted == other.isCompleted &&
+          isLoading == other.isLoading;
+
+  @override
+  int get hashCode =>
+      digits.hashCode ^
+      currentIndex.hashCode ^
+      error.hashCode ^
+      isCompleted.hashCode ^
+      isLoading.hashCode;
+}

--- a/packages/components/lib/src/components/text_field/cubit/text_field_cubit.dart
+++ b/packages/components/lib/src/components/text_field/cubit/text_field_cubit.dart
@@ -1,0 +1,173 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:osmea_components/src/components/text_field/cubit/text_field_state.dart';
+
+/// TextField Cubit for managing text field state
+class TextFieldCubit extends Cubit<TextFieldCubitState> {
+  final TextEditingController? controller;
+  final FocusNode? focusNode;
+  final String? Function(String?)? validator;
+  final ValueChanged<String>? onChanged;
+  final ValueChanged<bool>? onFocusChanged;
+  final ValueChanged<bool>? onHoverChanged;
+  final VoidCallback? onTap;
+  final ValueChanged<String>? onSubmitted;
+  final VoidCallback? onEditingComplete;
+
+  late TextEditingController _effectiveController;
+  late FocusNode _effectiveFocusNode;
+
+  TextFieldCubit({
+    this.controller,
+    this.focusNode,
+    this.validator,
+    this.onChanged,
+    this.onFocusChanged,
+    this.onHoverChanged,
+    this.onTap,
+    this.onSubmitted,
+    this.onEditingComplete,
+    bool enabled = true,
+    String initialValue = '',
+  }) : super(TextFieldCubitState(
+          isEnabled: enabled,
+          currentValue: initialValue,
+          hasValue: initialValue.isNotEmpty,
+        )) {
+    _initializeControllers();
+  }
+
+  /// Get the effective controller
+  TextEditingController get effectiveController => _effectiveController;
+
+  /// Get the effective focus node
+  FocusNode get effectiveFocusNode => _effectiveFocusNode;
+
+  void _initializeControllers() {
+    _effectiveController =
+        controller ?? TextEditingController(text: state.currentValue);
+    _effectiveFocusNode = focusNode ?? FocusNode();
+
+    // Add listeners
+    _effectiveController.addListener(_onTextChanged);
+    _effectiveFocusNode.addListener(_onFocusChanged);
+  }
+
+  /// Handle text changes
+  void _onTextChanged() {
+    final newValue = _effectiveController.text;
+    final hasValue = newValue.isNotEmpty;
+
+    // Validate if validator is provided
+    String? error;
+    if (validator != null) {
+      error = validator!(newValue);
+    }
+
+    emit(state.copyWith(
+      currentValue: newValue,
+      hasValue: hasValue,
+      errorMessage: error,
+    ));
+
+    onChanged?.call(newValue);
+  }
+
+  /// Handle focus changes
+  void _onFocusChanged() {
+    final hasFocus = _effectiveFocusNode.hasFocus;
+    emit(state.copyWith(isFocused: hasFocus));
+    onFocusChanged?.call(hasFocus);
+  }
+
+  /// Handle hover state changes
+  void setHover(bool isHovering) {
+    emit(state.copyWith(isHovering: isHovering));
+    onHoverChanged?.call(isHovering);
+  }
+
+  /// Handle tap events
+  void handleTap() {
+    _effectiveFocusNode.requestFocus();
+    onTap?.call();
+  }
+
+  /// Handle text submission
+  void handleSubmitted(String value) {
+    onSubmitted?.call(value);
+  }
+
+  /// Handle editing complete
+  void handleEditingComplete() {
+    onEditingComplete?.call();
+  }
+
+  /// Manually set focus
+  void requestFocus() {
+    _effectiveFocusNode.requestFocus();
+  }
+
+  /// Manually remove focus
+  void unfocus() {
+    _effectiveFocusNode.unfocus();
+  }
+
+  /// Set text value programmatically
+  void setText(String text) {
+    _effectiveController.text = text;
+    // _onTextChanged will be called automatically
+  }
+
+  /// Clear the text field
+  void clear() {
+    _effectiveController.clear();
+  }
+
+  /// Validate the current value
+  bool validate() {
+    if (validator != null) {
+      final error = validator!(state.currentValue);
+      emit(state.copyWith(errorMessage: error));
+      return error == null;
+    }
+    return true;
+  }
+
+  /// Set error message manually
+  void setError(String? error) {
+    emit(state.copyWith(errorMessage: error));
+  }
+
+  /// Set enabled state
+  void setEnabled(bool enabled) {
+    emit(state.copyWith(isEnabled: enabled));
+  }
+
+  /// Update hover progress for animations
+  void updateHoverProgress(double progress) {
+    emit(state.copyWith(hoverProgress: progress));
+  }
+
+  /// Update focus progress for animations
+  void updateFocusProgress(double progress) {
+    emit(state.copyWith(focusProgress: progress));
+  }
+
+  @override
+  Future<void> close() {
+    // Dispose controllers if we created them
+    if (controller == null) {
+      _effectiveController.dispose();
+    } else {
+      _effectiveController.removeListener(_onTextChanged);
+    }
+
+    if (focusNode == null) {
+      _effectiveFocusNode.dispose();
+    } else {
+      _effectiveFocusNode.removeListener(_onFocusChanged);
+    }
+
+    return super.close();
+  }
+}

--- a/packages/components/lib/src/components/text_field/cubit/text_field_state.dart
+++ b/packages/components/lib/src/components/text_field/cubit/text_field_state.dart
@@ -1,0 +1,78 @@
+/// TextField Cubit State representation
+class TextFieldCubitState {
+  final bool isHovering;
+  final bool isFocused;
+  final bool isEnabled;
+  final String? errorMessage;
+  final String currentValue;
+  final bool hasValue;
+  final double hoverProgress;
+  final double focusProgress;
+
+  const TextFieldCubitState({
+    this.isHovering = false,
+    this.isFocused = false,
+    this.isEnabled = true,
+    this.errorMessage,
+    this.currentValue = '',
+    this.hasValue = false,
+    this.hoverProgress = 0.0,
+    this.focusProgress = 0.0,
+  });
+
+  /// Whether the field is in an error state
+  bool get hasError => errorMessage != null;
+
+  /// Whether the field should show focus styling
+  bool get shouldShowFocus => isFocused || focusProgress > 0;
+
+  /// Whether the field should show hover styling
+  bool get shouldShowHover => isHovering || hoverProgress > 0;
+
+  TextFieldCubitState copyWith({
+    bool? isHovering,
+    bool? isFocused,
+    bool? isEnabled,
+    String? errorMessage,
+    String? currentValue,
+    bool? hasValue,
+    double? hoverProgress,
+    double? focusProgress,
+  }) {
+    return TextFieldCubitState(
+      isHovering: isHovering ?? this.isHovering,
+      isFocused: isFocused ?? this.isFocused,
+      isEnabled: isEnabled ?? this.isEnabled,
+      errorMessage: errorMessage,
+      currentValue: currentValue ?? this.currentValue,
+      hasValue: hasValue ?? this.hasValue,
+      hoverProgress: hoverProgress ?? this.hoverProgress,
+      focusProgress: focusProgress ?? this.focusProgress,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is TextFieldCubitState &&
+          runtimeType == other.runtimeType &&
+          isHovering == other.isHovering &&
+          isFocused == other.isFocused &&
+          isEnabled == other.isEnabled &&
+          errorMessage == other.errorMessage &&
+          currentValue == other.currentValue &&
+          hasValue == other.hasValue &&
+          hoverProgress == other.hoverProgress &&
+          focusProgress == other.focusProgress;
+
+  @override
+  int get hashCode =>
+      isHovering.hashCode ^
+      isFocused.hashCode ^
+      isEnabled.hashCode ^
+      errorMessage.hashCode ^
+      currentValue.hashCode ^
+      hasValue.hashCode ^
+      hoverProgress.hashCode ^
+      focusProgress.hashCode;
+}

--- a/packages/components/lib/src/components/text_field/otp_text_field.dart
+++ b/packages/components/lib/src/components/text_field/otp_text_field.dart
@@ -1,0 +1,268 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:osmea_components/osmea_components.dart';
+import 'package:osmea_components/src/components/center/center.dart';
+import 'package:osmea_components/src/components/column/column.dart';
+import 'package:osmea_components/src/components/padding/padding.dart';
+import 'package:osmea_components/src/components/text/text.dart';
+import 'package:osmea_components/src/components/wrap/wrap.dart';
+import 'package:osmea_components/src/core/text_field_widget.dart';
+import 'package:osmea_components/src/components/text_field/text_field.dart';
+
+/// 🔢 **OSMEA OTP TextField** - Cubit-based OTP Component
+///
+/// Stateless OTP component using Cubit for state management.
+/// Creates a row of individual digit input fields with auto-navigation.
+///
+/// **Features:**
+/// - Cubit-based state management (no StatefulWidget)
+/// - Configurable digit count (4, 5, 6 digits)
+/// - Auto-focus on next field
+/// - Backspace handling for previous field navigation
+/// - Copy-paste support
+/// - Custom styling per digit
+/// - Validation support
+/// - Responsive design
+/// - Accessibility features
+///
+/// **Usage:**
+/// ```dart
+/// OsmeaOTPTextField(
+///   digitCount: 6,
+///   onCompleted: (otp) => print('OTP: $otp'),
+///   onChanged: (otp) => print('Current: $otp'),
+///   validator: (otp) => otp?.length == 6 ? null : 'Invalid OTP',
+/// )
+/// ```
+///
+/// **Common Use Cases:**
+/// - SMS verification codes
+/// - Email verification
+/// - Two-factor authentication
+/// - Security PIN entry
+
+class OsmeaOTPTextField extends CoreTextField {
+  const OsmeaOTPTextField({
+    super.key,
+    this.digitCount = 6,
+    super.size = TextFieldSize.medium,
+    super.variant = TextFieldVariant.outlined,
+    this.spacing = 8.0,
+    this.onOTPChanged,
+    this.onOTPCompleted,
+    this.otpValidator,
+    this.autoFocus = true,
+    super.obscureText = false,
+    super.enabled = true,
+    super.backgroundColor,
+    super.borderColor,
+    super.focusColor,
+    super.errorColor,
+    super.textColor,
+    super.animationDuration,
+    this.pinInputDecoration,
+    this.showCursor = true,
+  }) : super(
+          type: TextFieldType.otp,
+          maxLength: digitCount,
+        );
+
+  /// Number of OTP digits (typically 4, 5, or 6)
+  final int digitCount;
+
+  /// Spacing between digit fields
+  final double spacing;
+
+  /// Called when OTP value changes
+  final ValueChanged<String>? onOTPChanged;
+
+  /// Called when OTP is completed (all digits filled)
+  final ValueChanged<String>? onOTPCompleted;
+
+  /// Validator for the complete OTP
+  final String? Function(String?)? otpValidator;
+
+  /// Whether to auto-focus first field
+  final bool autoFocus;
+
+  /// Whether to show cursor in fields
+  final bool showCursor;
+
+  /// Custom decoration for PIN input style
+  final BoxDecoration? pinInputDecoration;
+
+  @override
+  Widget buildWidget(BuildContext context) {
+    return BlocProvider(
+      create: (context) => OTPCubit(
+        digitCount: digitCount,
+        validator: otpValidator,
+        onChanged: onOTPChanged,
+        onCompleted: onOTPCompleted,
+      ),
+      child: _OTPFieldView(
+        digitCount: digitCount,
+        size: size,
+        variant: variant,
+        spacing: spacing,
+        autoFocus: autoFocus,
+        obscureText: obscureText,
+        enabled: enabled ?? true,
+        backgroundColor: backgroundColor,
+        borderColor: borderColor,
+        focusColor: focusColor,
+        errorColor: errorColor,
+        textColor: textColor,
+        animationDuration: animationDuration,
+        showCursor: showCursor,
+        pinInputDecoration: pinInputDecoration,
+      ),
+    );
+  }
+}
+
+/// Stateless OTP Field View using Cubit
+class _OTPFieldView extends StatelessWidget {
+  const _OTPFieldView({
+    required this.digitCount,
+    required this.size,
+    required this.variant,
+    required this.spacing,
+    required this.autoFocus,
+    required this.obscureText,
+    required this.enabled,
+    this.backgroundColor,
+    this.borderColor,
+    this.focusColor,
+    this.errorColor,
+    this.textColor,
+    this.animationDuration,
+    required this.showCursor,
+    this.pinInputDecoration,
+  });
+
+  final int digitCount;
+  final TextFieldSize size;
+  final TextFieldVariant variant;
+  final double spacing;
+  final bool autoFocus;
+  final bool obscureText;
+  final bool enabled;
+  final Color? backgroundColor;
+  final Color? borderColor;
+  final Color? focusColor;
+  final Color? errorColor;
+  final Color? textColor;
+  final Duration? animationDuration;
+  final bool showCursor;
+  final BoxDecoration? pinInputDecoration;
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocConsumer<OTPCubit, OTPState>(
+      listener: (context, state) {
+        if (autoFocus && state.digits.every((d) => d.isEmpty)) {
+          // Auto-focus first field when cleared
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            context.read<OTPCubit>().autoFocus();
+          });
+        }
+      },
+      builder: (context, state) {
+        // Responsive spacing calculation
+        final screenWidth = MediaQuery.of(context).size.width;
+        final config = size.getConfig(context);
+        final totalFieldWidth = config.height * digitCount;
+        final totalSpacing = spacing * (digitCount - 1);
+        final totalWidth = totalFieldWidth + totalSpacing + 32;
+        final adaptiveSpacing = totalWidth > screenWidth
+            ? (screenWidth - totalFieldWidth - 32) / (digitCount - 1)
+            : spacing;
+        final finalSpacing = adaptiveSpacing.clamp(4.0, spacing);
+
+        return Focus(
+          onKeyEvent: (node, event) {
+            context.read<OTPCubit>().onKeyEvent(event);
+            return KeyEventResult.ignored;
+          },
+          child: OsmeaColumn(
+            crossAxisAlignment: crossStart,
+            mainAxisSize: min,
+            children: [
+              OsmeaCenter(
+                child: OsmeaWrap(
+                  alignment: wrapCenter,
+                  children: List.generate(digitCount, (index) {
+                    return OsmeaPadding(
+                      padding: EdgeInsets.only(
+                        right: index < digitCount - 1 ? finalSpacing : 0,
+                        bottom: 4.0,
+                      ),
+                      child: _buildDigitField(context, index, state),
+                    );
+                  }),
+                ),
+              ),
+              if (state.error != null) ...[
+                context.emptySizedHeightBoxLow,
+                OsmeaText(
+                  state.error!,
+                  style: OsmeaTextStyle.overline(context).copyWith(
+                    color: errorColor ?? OsmeaColors.amberFlame,
+                    fontSize: context.fontSizeSmall,
+                  ),
+                ),
+              ],
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildDigitField(BuildContext context, int index, OTPState state) {
+    final config = size.getConfig(context);
+    final cubit = context.read<OTPCubit>();
+
+    return SizedBox(
+      width: config.height,
+      child: GestureDetector(
+        onLongPress: () {
+          cubit.onLongPressBackspace();
+        },
+        child: OsmeaTextField(
+          controller: cubit.controllers[index],
+          focusNode: cubit.focusNodes[index],
+          type: TextFieldType.number,
+          variant: variant,
+          size: size,
+          maxLength: 1,
+          textAlign: textCenter,
+          obscureText: obscureText,
+          enabled: enabled,
+          backgroundColor: backgroundColor,
+          borderColor: borderColor,
+          focusColor: focusColor,
+          errorColor: errorColor,
+          textColor: textColor,
+          animationDuration: animationDuration,
+          inputFormatters: [
+            FilteringTextInputFormatter.digitsOnly,
+            LengthLimitingTextInputFormatter(1),
+          ],
+          onTap: () => cubit.focusField(index),
+          onChanged: (value) => cubit.onDigitChanged(index, value),
+        ),
+      ),
+    );
+  }
+}
+
+/// Extension to provide easy access to OTP Cubit methods
+extension OTPTextFieldExtension on OsmeaOTPTextField {
+  /// Get the OTP Cubit from context
+  static OTPCubit of(BuildContext context) {
+    return BlocProvider.of<OTPCubit>(context);
+  }
+}

--- a/packages/components/lib/src/components/text_field/text_field.dart
+++ b/packages/components/lib/src/components/text_field/text_field.dart
@@ -1,0 +1,629 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:osmea_components/src/core/text_field_widget.dart';
+import 'package:osmea_components/src/components/text_field/controllers/text_field_controller.dart';
+import 'package:osmea_components/src/utils/text_field_size_extensions.dart';
+import 'package:osmea_components/src/utils/sizer_extensions.dart';
+import 'package:osmea_components/src/styles/colors.dart';
+import 'package:osmea_components/src/enums/components_enum.dart';
+import 'package:osmea_components/src/components/text_field/cubit/text_field_cubit.dart';
+import 'package:osmea_components/src/components/text_field/cubit/text_field_state.dart';
+
+/// 🔤 **OSMEA TextField**
+///
+/// A comprehensive and highly customizable text field component for the OSMEA UI Kit.
+/// Features advanced state management, validation, theming, and extensive customization options.
+///
+/// **Features:**
+/// - Multiple OSMEA variants (outlined, filled, underlined, borderless)
+/// - Size options (extraSmall to extraLarge)
+/// - Input types (text, email, password, number, etc.)
+/// - Advanced validation with custom error builders
+/// - Animated state transitions and hover effects
+/// - Interactive states (hover, focus, disabled)
+/// - Custom error and helper text builders
+/// - Floating label support
+/// - Responsive design with OSMEA color system
+/// - Accessibility features
+///
+/// **Usage:**
+/// ```dart
+/// OsmeaTextField(
+///   label: 'Email Address',
+///   hint: 'Enter your email',
+///   type: TextFieldType.email,
+///   variant: TextFieldVariant.outlined,
+///   size: TextFieldSize.medium,
+///   showErrorIcon: true,
+///   hasFloatingLabel: true,
+///   errorBuilder: (context, error) => CustomErrorWidget(error),
+///   onChanged: (value) => print(value),
+///   onFocusChanged: (hasFocus) => print('Focus: $hasFocus'),
+///   onHoverChanged: (isHovering) => print('Hover: $isHovering'),
+/// )
+/// ```
+
+class OsmeaTextField extends CoreTextField {
+  const OsmeaTextField({
+    super.key,
+    super.customTheme,
+    super.controller,
+    this.osmeaController,
+    super.focusNode,
+    super.label,
+    super.hint,
+    super.helperText,
+    super.errorText,
+    super.prefixIcon,
+    super.suffixIcon,
+    super.size,
+    super.variant,
+    super.state,
+    super.type,
+    super.isRequired,
+    super.validator,
+    super.onChanged,
+    super.onSubmitted,
+    super.onTap,
+    super.onEditingComplete,
+    super.maxLines,
+    super.minLines,
+    super.maxLength,
+    super.obscureText,
+    super.readOnly,
+    super.autofocus,
+    super.enabled,
+    super.textAlign,
+    super.textCapitalization,
+    super.keyboardType,
+    super.textInputAction,
+    super.inputFormatters,
+    super.textStyle,
+    super.textColor,
+    super.backgroundColor,
+    super.borderColor,
+    super.focusColor,
+    super.errorColor,
+    super.hintColor,
+    super.labelColor,
+    super.fullWidth,
+    super.animationDuration,
+    // Advanced OSMEA-specific parameters
+    this.hasFloatingLabel = false,
+    this.showErrorIcon = true,
+    this.errorMaxLines = 2,
+    this.transitionDuration,
+    this.transitionCurve = Curves.easeInOut,
+    this.onFocusChanged,
+    this.onHoverChanged,
+    this.errorBuilder,
+    this.helperBuilder,
+    this.interactiveStates = const {
+      WidgetState.hovered,
+      WidgetState.focused,
+      WidgetState.pressed,
+    },
+    this.enableHoverEffect = true,
+    this.hoverAnimationDuration,
+    this.customBorderRadius,
+    this.showCharacterCount = false,
+    this.characterCountBuilder,
+  });
+
+  /// Optional OSMEA-specific controller with enhanced features
+  final OsmeaTextFieldController? osmeaController;
+
+  /// Whether the label should float above the field when focused or filled
+  final bool hasFloatingLabel;
+
+  /// Whether to show an error icon when there's an error
+  final bool showErrorIcon;
+
+  /// Maximum number of lines for error text
+  final int errorMaxLines;
+
+  /// Custom transition duration for state changes
+  final Duration? transitionDuration;
+
+  /// Animation curve for transitions
+  final Curve transitionCurve;
+
+  /// Callback when focus state changes
+  final ValueChanged<bool>? onFocusChanged;
+
+  /// Callback when hover state changes
+  final ValueChanged<bool>? onHoverChanged;
+
+  /// Custom builder for error messages
+  final Widget Function(BuildContext context, String error)? errorBuilder;
+
+  /// Custom builder for helper text
+  final Widget Function(BuildContext context, String helper)? helperBuilder;
+
+  /// Set of material states that should trigger interactive effects
+  final Set<WidgetState> interactiveStates;
+
+  /// Whether hover effects are enabled
+  final bool enableHoverEffect;
+
+  /// Duration for hover animations
+  final Duration? hoverAnimationDuration;
+
+  /// Custom border radius override
+  final BorderRadius? customBorderRadius;
+
+  /// Whether to show character count
+  final bool showCharacterCount;
+
+  /// Custom builder for character count display
+  final Widget Function(BuildContext context, int current, int? max)?
+      characterCountBuilder;
+
+  /// Get the effective controller (OSMEA controller takes priority)
+  TextEditingController get effectiveController =>
+      osmeaController ?? controller ?? TextEditingController();
+
+  /// Get effective transition duration
+  Duration getEffectiveTransitionDuration(BuildContext context) =>
+      transitionDuration ?? animationDuration ?? context.animationMedium;
+
+  /// Get effective hover animation duration
+  Duration getEffectiveHoverDuration(BuildContext context) =>
+      hoverAnimationDuration ?? const Duration(milliseconds: 150);
+
+  @override
+  Widget buildWidget(BuildContext context) {
+    return BlocProvider(
+      create: (context) => TextFieldCubit(
+        controller: effectiveController,
+        focusNode: focusNode,
+        validator: validator,
+        onChanged: onChanged,
+        onFocusChanged: onFocusChanged,
+        onHoverChanged: onHoverChanged,
+        onTap: onTap,
+        onSubmitted: onSubmitted,
+        onEditingComplete: onEditingComplete,
+        enabled: enabled ?? true,
+        initialValue: effectiveController.text,
+      ),
+      child: _OsmeaTextFieldView(
+        textField: this,
+      ),
+    );
+  }
+}
+
+/// Stateless TextField View using Cubit
+class _OsmeaTextFieldView extends StatelessWidget {
+  const _OsmeaTextFieldView({
+    required this.textField,
+  });
+
+  final OsmeaTextField textField;
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<TextFieldCubit, TextFieldCubitState>(
+      builder: (context, state) {
+        final config = textField.size.getConfig(context);
+        final colors = _getTextFieldColors(context, state);
+
+        return MouseRegion(
+          onEnter: (_) => context.read<TextFieldCubit>().setHover(true),
+          onExit: (_) => context.read<TextFieldCubit>().setHover(false),
+          child: AnimatedContainer(
+            duration: textField.getEffectiveTransitionDuration(context),
+            curve: textField.transitionCurve,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                if (textField.label != null && !textField.hasFloatingLabel)
+                  _buildLabel(context, config, colors, state),
+                _buildTextField(context, config, colors, state),
+                _buildBottomSection(context, config, colors, state),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  /// Build the label widget
+  Widget _buildLabel(BuildContext context, TextFieldSizeConfig config,
+      _TextFieldColors colors, TextFieldCubitState state) {
+    return Padding(
+      padding: EdgeInsets.only(bottom: config.labelSpacing),
+      child: Row(
+        children: [
+          Text(
+            textField.label!,
+            style: textField.size.getLabelStyle(context).copyWith(
+                  color: colors.label,
+                ),
+          ),
+          if (textField.isRequired) ...[
+            SizedBox(width: context.spacing4),
+            Text(
+              '*',
+              style: textField.size.getLabelStyle(context).copyWith(
+                    color: colors.error,
+                  ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  /// Build the main text field widget
+  Widget _buildTextField(
+    BuildContext context,
+    TextFieldSizeConfig config,
+    _TextFieldColors colors,
+    TextFieldCubitState state,
+  ) {
+    final cubit = context.read<TextFieldCubit>();
+    final decoration = _buildInputDecoration(context, config, colors, state);
+
+    return AnimatedContainer(
+      duration: textField.getEffectiveTransitionDuration(context),
+      curve: textField.transitionCurve,
+      constraints: BoxConstraints(
+        minHeight: config.height,
+        maxWidth: textField.fullWidth ? double.infinity : double.maxFinite,
+      ),
+      child: TextField(
+        controller: cubit.effectiveController,
+        focusNode: cubit.effectiveFocusNode,
+        decoration: decoration,
+        keyboardType: textField.effectiveKeyboardType,
+        textInputAction: textField.effectiveTextInputAction,
+        textCapitalization: textField.effectiveTextCapitalization,
+        style: _getInputTextStyle(context, config, colors, state),
+        maxLines: textField.maxLines,
+        minLines: textField.minLines,
+        maxLength: textField.maxLength,
+        obscureText: textField.shouldObscureText,
+        readOnly: textField.readOnly,
+        autofocus: textField.autofocus,
+        enabled: state.isEnabled && !textField.isEffectivelyDisabled,
+        textAlign: textField.textAlign,
+        inputFormatters: textField.inputFormatters,
+        canRequestFocus: true,
+        showCursor: true,
+        enableInteractiveSelection: true,
+        onTap: () => cubit.handleTap(),
+        onChanged: (value) => cubit.validate(),
+        onSubmitted: (value) => cubit.handleSubmitted(value),
+        onEditingComplete: () => cubit.handleEditingComplete(),
+      ),
+    );
+  }
+
+  /// Build bottom section with helper text, error text, and character count
+  Widget _buildBottomSection(BuildContext context, TextFieldSizeConfig config,
+      _TextFieldColors colors, TextFieldCubitState state) {
+    final shouldShowHelper = _shouldShowHelperText(state);
+    final shouldShowCount =
+        textField.showCharacterCount && textField.maxLength != null;
+
+    if (!shouldShowHelper && !shouldShowCount) {
+      return const SizedBox.shrink();
+    }
+
+    return Padding(
+      padding: EdgeInsets.only(top: config.helperSpacing),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          if (shouldShowHelper)
+            Expanded(
+                child: _buildHelperOrErrorText(context, config, colors, state)),
+          if (shouldShowCount)
+            _buildCharacterCount(context, config, colors, state),
+        ],
+      ),
+    );
+  }
+
+  /// Build helper or error text with custom builders
+  Widget _buildHelperOrErrorText(
+      BuildContext context,
+      TextFieldSizeConfig config,
+      _TextFieldColors colors,
+      TextFieldCubitState state) {
+    final displayText = _getDisplayHelperText(state);
+    final isError = _isErrorText(state);
+
+    // Use custom error builder if available and it's an error
+    if (isError && textField.errorBuilder != null) {
+      return AnimatedSwitcher(
+        duration: textField.getEffectiveTransitionDuration(context),
+        child: textField.errorBuilder!(context, displayText),
+      );
+    }
+
+    // Use custom helper builder if available and it's not an error
+    if (!isError && textField.helperBuilder != null) {
+      return textField.helperBuilder!(context, displayText);
+    }
+
+    // Default text display
+    return AnimatedSwitcher(
+      duration: textField.getEffectiveTransitionDuration(context),
+      child: Row(
+        key: ValueKey(displayText),
+        children: [
+          if (isError && textField.showErrorIcon) ...[
+            Icon(
+              Icons.error_outline,
+              size: config.iconSize * 0.8,
+              color: colors.error,
+            ),
+            SizedBox(width: context.spacing2),
+          ],
+          Expanded(
+            child: Text(
+              displayText,
+              style: textField.size.getHelperStyle(context).copyWith(
+                    color: isError ? colors.error : colors.helper,
+                  ),
+              maxLines: isError ? textField.errorMaxLines : null,
+              overflow: isError ? TextOverflow.ellipsis : null,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// Build character count display
+  Widget _buildCharacterCount(BuildContext context, TextFieldSizeConfig config,
+      _TextFieldColors colors, TextFieldCubitState state) {
+    final currentLength = state.currentValue.length;
+    final maxLength = textField.maxLength!;
+
+    if (textField.characterCountBuilder != null) {
+      return textField.characterCountBuilder!(
+          context, currentLength, maxLength);
+    }
+
+    final isOverLimit = currentLength > maxLength;
+    return Text(
+      '$currentLength/$maxLength',
+      style: textField.size.getHelperStyle(context).copyWith(
+            color: isOverLimit ? colors.error : colors.helper,
+          ),
+    );
+  }
+
+  /// Build input decoration
+  InputDecoration _buildInputDecoration(
+    BuildContext context,
+    TextFieldSizeConfig config,
+    _TextFieldColors colors,
+    TextFieldCubitState state,
+  ) {
+    return InputDecoration(
+      labelText: textField.hasFloatingLabel ? textField.label : null,
+      labelStyle: textField.hasFloatingLabel
+          ? textField.size.getLabelStyle(context).copyWith(color: colors.label)
+          : null,
+      floatingLabelStyle: textField.hasFloatingLabel
+          ? textField.size.getLabelStyle(context).copyWith(color: colors.focus)
+          : null,
+      hintText: textField.hint,
+      hintStyle: _getHintTextStyle(context, config, colors, state),
+      prefixIcon: textField.prefixIcon != null
+          ? _buildIcon(textField.prefixIcon!, config, colors, state)
+          : null,
+      suffixIcon: textField.suffixIcon != null
+          ? _buildIcon(textField.suffixIcon!, config, colors, state)
+          : null,
+      filled: textField.variant == TextFieldVariant.filled ||
+          textField.variant == TextFieldVariant.borderless,
+      fillColor: colors.background,
+      contentPadding: config.padding,
+      border: _getBorder(context, config, colors.border, state),
+      enabledBorder: _getBorder(context, config, colors.border, state),
+      focusedBorder: _getBorder(context, config, colors.focus, state),
+      errorBorder: _getBorder(context, config, colors.error, state),
+      focusedErrorBorder: _getBorder(context, config, colors.error, state),
+      disabledBorder: _getBorder(context, config, colors.disabled, state),
+      counterText: '', // Hide default character counter
+    );
+  }
+
+  /// Build icon wrapper with proper theming
+  Widget _buildIcon(Widget icon, TextFieldSizeConfig config,
+      _TextFieldColors colors, TextFieldCubitState state) {
+    return IconTheme(
+      data: IconThemeData(
+        size: config.iconSize,
+        color: !state.isEnabled || textField.isEffectivelyDisabled
+            ? colors.disabled
+            : colors.icon,
+      ),
+      child: icon,
+    );
+  }
+
+  /// Get border based on variant and state with animation support
+  InputBorder _getBorder(BuildContext context, TextFieldSizeConfig config,
+      Color color, TextFieldCubitState state) {
+    final borderRadius = textField.customBorderRadius ?? config.borderRadius;
+    final borderWidth = _getBorderWidth(state);
+
+    switch (textField.variant) {
+      case TextFieldVariant.outlined:
+        return OutlineInputBorder(
+          borderRadius: borderRadius,
+          borderSide: BorderSide(color: color, width: borderWidth),
+        );
+      case TextFieldVariant.filled:
+        return OutlineInputBorder(
+          borderRadius: borderRadius,
+          borderSide: BorderSide(
+              color: color.withValues(alpha: 0.3), width: borderWidth),
+        );
+      case TextFieldVariant.underlined:
+        return UnderlineInputBorder(
+          borderSide: BorderSide(color: color, width: borderWidth),
+        );
+      case TextFieldVariant.borderless:
+        return InputBorder.none;
+    }
+  }
+
+  /// Get border width based on focus and hover state
+  double _getBorderWidth(TextFieldCubitState state) {
+    if (state.isFocused) return 2.0;
+    if (state.isHovering && textField.enableHoverEffect) return 1.5;
+    return 1.0;
+  }
+
+  /// Get input text style
+  TextStyle _getInputTextStyle(BuildContext context, TextFieldSizeConfig config,
+      _TextFieldColors colors, TextFieldCubitState state) {
+    return (textField.textStyle ?? textField.size.getInputStyle(context))
+        .copyWith(
+      color: !state.isEnabled || textField.isEffectivelyDisabled
+          ? colors.disabled
+          : (textField.textColor ?? colors.text),
+    );
+  }
+
+  /// Get hint text style
+  TextStyle _getHintTextStyle(BuildContext context, TextFieldSizeConfig config,
+      _TextFieldColors colors, TextFieldCubitState state) {
+    return textField.size.getInputStyle(context).copyWith(
+          color: textField.hintColor ?? colors.hint,
+        );
+  }
+
+  /// Get text field colors based on theme and state
+  _TextFieldColors _getTextFieldColors(
+      BuildContext context, TextFieldCubitState state) {
+    final baseColors = _TextFieldColors(
+      text: textField.textColor ??
+          (!state.isEnabled || textField.isEffectivelyDisabled
+              ? OsmeaColors.steel
+              : OsmeaColors.eclipse),
+      hint: textField.hintColor ?? OsmeaColors.pewter,
+      label: textField.labelColor ??
+          (state.hasError ? OsmeaColors.amberFlame : OsmeaColors.slate),
+      background: textField.backgroundColor ??
+          (textField.variant == TextFieldVariant.filled
+              ? OsmeaColors.ash
+              : OsmeaColors.transparent),
+      border: textField.borderColor ??
+          (state.hasError ? OsmeaColors.amberFlame : OsmeaColors.silver),
+      focus: textField.focusColor ?? OsmeaColors.nordicBlue,
+      error: textField.errorColor ?? OsmeaColors.amberFlame,
+      success: OsmeaColors.forestHeart,
+      warning: OsmeaColors.sunsetGlow,
+      helper: OsmeaColors.pewter,
+      disabled: OsmeaColors.silver,
+      icon: OsmeaColors.slate,
+    );
+
+    // Apply hover and focus color modifications
+    if (state.isFocused) {
+      return baseColors.copyWith(
+        border: baseColors.focus,
+        label: baseColors.focus,
+      );
+    }
+
+    if (state.isHovering && textField.enableHoverEffect) {
+      return baseColors.copyWith(
+        border: Color.lerp(baseColors.border, baseColors.focus, 0.3),
+      );
+    }
+
+    return baseColors;
+  }
+
+  /// Whether to show helper text
+  bool _shouldShowHelperText(TextFieldCubitState state) {
+    return textField.helperText != null ||
+        textField.errorText != null ||
+        state.hasError;
+  }
+
+  /// Get the text to display in helper area
+  String _getDisplayHelperText(TextFieldCubitState state) {
+    if (textField.errorText != null) return textField.errorText!;
+    if (state.hasError) return state.errorMessage!;
+    return textField.helperText ?? '';
+  }
+
+  /// Whether the helper text is an error
+  bool _isErrorText(TextFieldCubitState state) {
+    return textField.errorText != null || state.hasError || textField.hasError;
+  }
+}
+
+/// Internal helper class for text field colors
+class _TextFieldColors {
+  const _TextFieldColors({
+    required this.text,
+    required this.hint,
+    required this.label,
+    required this.background,
+    required this.border,
+    required this.focus,
+    required this.error,
+    required this.success,
+    required this.warning,
+    required this.helper,
+    required this.disabled,
+    required this.icon,
+  });
+
+  final Color text;
+  final Color hint;
+  final Color label;
+  final Color background;
+  final Color border;
+  final Color focus;
+  final Color error;
+  final Color success;
+  final Color warning;
+  final Color helper;
+  final Color disabled;
+  final Color icon;
+
+  _TextFieldColors copyWith({
+    Color? text,
+    Color? hint,
+    Color? label,
+    Color? background,
+    Color? border,
+    Color? focus,
+    Color? error,
+    Color? success,
+    Color? warning,
+    Color? helper,
+    Color? disabled,
+    Color? icon,
+  }) {
+    return _TextFieldColors(
+      text: text ?? this.text,
+      hint: hint ?? this.hint,
+      label: label ?? this.label,
+      background: background ?? this.background,
+      border: border ?? this.border,
+      focus: focus ?? this.focus,
+      error: error ?? this.error,
+      success: success ?? this.success,
+      warning: warning ?? this.warning,
+      helper: helper ?? this.helper,
+      disabled: disabled ?? this.disabled,
+      icon: icon ?? this.icon,
+    );
+  }
+}

--- a/packages/components/lib/src/core/text_field_widget.dart
+++ b/packages/components/lib/src/core/text_field_widget.dart
@@ -1,0 +1,277 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:osmea_components/src/core/abstract/abstract_core_widget.dart';
+import 'package:osmea_components/src/enums/components_enum.dart';
+
+/// 📝 **Core TextField Widget**
+///
+/// Abstract base class for all text input components in the OSMEA UI Kit.
+/// Provides the foundation for text fields with consistent behavior and styling.
+///
+/// **Features:**
+/// - 🎨 Custom theming support
+/// - 📏 Flexible sizing and constraints
+/// - 🔤 Rich input formatting options
+/// - 🌐 Internationalization support
+/// - ♿ Accessibility features
+/// - 🎯 Validation support
+///
+/// **Properties:**
+/// - Text editing and focus management
+/// - Input validation and formatting
+/// - Keyboard type and behavior
+/// - Visual styling and theming
+///
+/// @category Core
+/// @subcategory Widgets
+
+abstract class CoreTextField extends AbstractCoreWidget {
+  const CoreTextField({
+    super.key,
+    super.customTheme,
+    this.controller,
+    this.focusNode,
+    this.label,
+    this.hint,
+    this.helperText,
+    this.errorText,
+    this.prefixIcon,
+    this.suffixIcon,
+    this.size = TextFieldSize.medium,
+    this.variant = TextFieldVariant.outlined,
+    this.state = TextFieldState.enabled,
+    this.type = TextFieldType.text,
+    this.isRequired = false,
+    this.validator,
+    this.onChanged,
+    this.onSubmitted,
+    this.onTap,
+    this.onEditingComplete,
+    this.maxLines = 1,
+    this.minLines,
+    this.maxLength,
+    this.obscureText = false,
+    this.readOnly = false,
+    this.autofocus = false,
+    this.enabled,
+    this.textAlign = TextAlign.start,
+    this.textCapitalization = TextCapitalization.none,
+    this.keyboardType,
+    this.textInputAction,
+    this.inputFormatters,
+    this.textStyle,
+    this.textColor,
+    this.backgroundColor,
+    this.borderColor,
+    this.focusColor,
+    this.errorColor,
+    this.hintColor,
+    this.labelColor,
+    this.fullWidth = false,
+    this.animationDuration,
+  });
+
+  // Core TextField Properties
+
+  /// Text editing controller for managing input text
+  final TextEditingController? controller;
+
+  /// Focus node for managing keyboard focus
+  final FocusNode? focusNode;
+
+  /// Label text displayed above the input field
+  final String? label;
+
+  /// Hint text shown when field is empty
+  final String? hint;
+
+  /// Helper text shown below the field
+  final String? helperText;
+
+  /// Error text shown when validation fails
+  final String? errorText;
+
+  /// Widget displayed at the start of the input field
+  final Widget? prefixIcon;
+
+  /// Widget displayed at the end of the input field
+  final Widget? suffixIcon;
+
+  /// Size variant controlling height and spacing
+  final TextFieldSize size;
+
+  /// Visual style variant
+  final TextFieldVariant variant;
+
+  /// Current state of the text field
+  final TextFieldState state;
+
+  /// Input type determining keyboard and behavior
+  final TextFieldType type;
+
+  /// Whether the field is required (shows asterisk)
+  final bool isRequired;
+
+  /// Validation function for input text
+  final String? Function(String?)? validator;
+
+  // Event Callbacks
+
+  /// Called when text changes
+  final ValueChanged<String>? onChanged;
+
+  /// Called when user submits text
+  final ValueChanged<String>? onSubmitted;
+
+  /// Called when field is tapped
+  final GestureTapCallback? onTap;
+
+  /// Called when editing is complete
+  final VoidCallback? onEditingComplete;
+
+  // Input Configuration
+
+  /// Maximum number of lines (null for unlimited)
+  final int? maxLines;
+
+  /// Minimum number of lines
+  final int? minLines;
+
+  /// Maximum number of characters
+  final int? maxLength;
+
+  /// Whether to obscure text (for passwords)
+  final bool obscureText;
+
+  /// Whether field is read-only
+  final bool readOnly;
+
+  /// Whether to auto-focus on build
+  final bool autofocus;
+
+  /// Whether field is enabled (null = auto from state)
+  final bool? enabled;
+
+  /// Text alignment within the field
+  final TextAlign textAlign;
+
+  /// Capitalization behavior
+  final TextCapitalization textCapitalization;
+
+  /// Keyboard type override
+  final TextInputType? keyboardType;
+
+  /// Text input action override
+  final TextInputAction? textInputAction;
+
+  /// Input formatters for text processing
+  final List<TextInputFormatter>? inputFormatters;
+
+  // Styling Properties
+
+  /// Custom text style
+  final TextStyle? textStyle;
+
+  /// Text color override
+  final Color? textColor;
+
+  /// Background color override
+  final Color? backgroundColor;
+
+  /// Border color override
+  final Color? borderColor;
+
+  /// Focus color override
+  final Color? focusColor;
+
+  /// Error color override
+  final Color? errorColor;
+
+  /// Hint text color override
+  final Color? hintColor;
+
+  /// Label text color override
+  final Color? labelColor;
+
+  /// Whether field should take full width
+  final bool fullWidth;
+
+  /// Animation duration for state changes
+  final Duration? animationDuration;
+
+  // Computed Properties
+
+  /// Whether the field is effectively disabled
+  bool get isEffectivelyDisabled =>
+      enabled == false || state == TextFieldState.disabled;
+
+  /// Whether the field has an error state
+  bool get hasError => state == TextFieldState.error || errorText != null;
+
+  /// Whether the field has focus
+  bool get hasFocus => state == TextFieldState.focused;
+
+  /// Whether the field is in success state
+  bool get hasSuccess => state == TextFieldState.success;
+
+  /// Whether the field shows warning
+  bool get hasWarning => state == TextFieldState.warning;
+
+  /// Effective keyboard type based on type
+  TextInputType get effectiveKeyboardType {
+    if (keyboardType != null) return keyboardType!;
+
+    switch (type) {
+      case TextFieldType.email:
+        return TextInputType.emailAddress;
+      case TextFieldType.password:
+        return TextInputType.visiblePassword;
+      case TextFieldType.number:
+        return TextInputType.number;
+      case TextFieldType.phone:
+        return TextInputType.phone;
+      case TextFieldType.url:
+        return TextInputType.url;
+      case TextFieldType.search:
+        return TextInputType.text;
+      case TextFieldType.multiline:
+        return TextInputType.multiline;
+      case TextFieldType.text:
+      default:
+        return TextInputType.text;
+    }
+  }
+
+  /// Effective text input action based on type
+  TextInputAction get effectiveTextInputAction {
+    if (textInputAction != null) return textInputAction!;
+
+    switch (type) {
+      case TextFieldType.search:
+        return TextInputAction.search;
+      case TextFieldType.multiline:
+        return TextInputAction.newline;
+      case TextFieldType.email:
+        return TextInputAction.next;
+      default:
+        return TextInputAction.done;
+    }
+  }
+
+  /// Whether text should be obscured
+  bool get shouldObscureText => obscureText || type == TextFieldType.password;
+
+  /// Effective text capitalization based on type
+  TextCapitalization get effectiveTextCapitalization {
+    switch (type) {
+      case TextFieldType.email:
+      case TextFieldType.password:
+      case TextFieldType.url:
+        return TextCapitalization.none;
+      case TextFieldType.text:
+        return textCapitalization;
+      default:
+        return textCapitalization;
+    }
+  }
+}

--- a/packages/components/lib/src/enums/components_enum.dart
+++ b/packages/components/lib/src/enums/components_enum.dart
@@ -430,10 +430,223 @@ enum ComponentEmphasis {
   medium,
 
   /// 🔼 **High** - Increased emphasis
-  /// - Important elements that need attention
+  /// - Important elements, primary CTAs
   high,
 
   /// 🚨 **Critical** - Maximum emphasis
-  /// - Urgent information requiring immediate action
+  /// - Critical alerts, destructive actions
   critical,
+}
+
+/// 🔤 **TextField Size**
+///
+/// Size variants for text input fields.
+/// Controls height, padding, and font size of text fields.
+///
+/// **Size Guidelines:**
+/// - `extraSmall`: Compact text fields for tight spaces
+/// - `small`: Reduced size for secondary inputs
+/// - `medium`: Standard size for most forms (default)
+/// - `large`: Prominent size for important inputs
+/// - `extraLarge`: Hero size for primary form fields
+///
+/// **Usage:**
+/// ```dart
+/// OsmeaComponents.textField(
+///   size: TextFieldSize.medium,
+///   label: 'Email',
+/// )
+/// ```
+enum TextFieldSize {
+  /// 🔹 **Extra Small** - Compact text fields
+  /// - Height: ~32px
+  /// - Font: 12px
+  /// - Use for: Inline editing, table cells, compact forms
+  extraSmall,
+
+  /// 🔸 **Small** - Reduced size text fields
+  /// - Height: ~36px
+  /// - Font: 13px
+  /// - Use for: Secondary inputs, filter fields
+  small,
+
+  /// 🔶 **Medium** - Standard text fields (default)
+  /// - Height: ~44px
+  /// - Font: 14px
+  /// - Use for: Most form inputs, standard UI
+  medium,
+
+  /// 🔷 **Large** - Prominent text fields
+  /// - Height: ~52px
+  /// - Font: 16px
+  /// - Use for: Important inputs, mobile-first design
+  large,
+
+  /// 🔵 **Extra Large** - Hero text fields
+  /// - Height: ~60px
+  /// - Font: 18px
+  /// - Use for: Primary forms, hero sections
+  extraLarge,
+}
+
+/// 🎨 **TextField Variant**
+///
+/// Visual style variants for text input fields.
+/// Controls the appearance and styling of text fields.
+///
+/// **Variant Guidelines:**
+/// - `outlined`: Border with transparent background
+/// - `filled`: Solid background with subtle border
+/// - `underlined`: Bottom border only, minimal style
+/// - `borderless`: No border, background only
+///
+/// **Usage:**
+/// ```dart
+/// OsmeaComponents.textField(
+///   variant: TextFieldVariant.outlined,
+///   label: 'Username',
+/// )
+/// ```
+enum TextFieldVariant {
+  /// 📦 **Outlined** - Border with transparent background
+  /// - Clear boundary definition
+  /// - Good for forms and structured layouts
+  outlined,
+
+  /// 🎨 **Filled** - Solid background with subtle border
+  /// - Emphasized input area
+  /// - Good for modern, card-based designs
+  filled,
+
+  /// 📝 **Underlined** - Bottom border only
+  /// - Minimal, clean appearance
+  /// - Good for simple forms and clean designs
+  underlined,
+
+  /// 👻 **Borderless** - No border, background only
+  /// - Seamless integration
+  /// - Good for inline editing and minimal interfaces
+  borderless,
+}
+
+/// 🔄 **TextField State**
+///
+/// Interactive and validation states for text input fields.
+/// Controls appearance based on user interaction and validation.
+///
+/// **State Guidelines:**
+/// - `enabled`: Normal interactive state
+/// - `disabled`: Non-interactive state
+/// - `focused`: Has keyboard focus
+/// - `error`: Has validation error
+/// - `success`: Validation passed
+/// - `warning`: Requires attention
+///
+/// **Usage:**
+/// ```dart
+/// OsmeaComponents.textField(
+///   state: hasError ? TextFieldState.error : TextFieldState.enabled,
+///   errorText: errorMessage,
+/// )
+/// ```
+enum TextFieldState {
+  /// ✅ **Enabled** - Normal interactive state
+  /// - Ready for user input
+  /// - Default appearance
+  enabled,
+
+  /// ⚫ **Disabled** - Non-interactive state
+  /// - Grayed out appearance
+  /// - No user interaction possible
+  disabled,
+
+  /// 🎯 **Focused** - Has keyboard focus
+  /// - Highlighted border/background
+  /// - Active input state
+  focused,
+
+  /// ❌ **Error** - Has validation error
+  /// - Red/error coloring
+  /// - Shows error message
+  error,
+
+  /// ✅ **Success** - Validation passed
+  /// - Green/success coloring
+  /// - Positive feedback
+  success,
+
+  /// ⚠️ **Warning** - Requires attention
+  /// - Yellow/warning coloring
+  /// - Cautionary message
+  warning,
+}
+
+/// 🎯 **TextField Type**
+///
+/// Input types that determine keyboard and behavior.
+/// Automatically configures appropriate keyboard and validation.
+///
+/// **Type Guidelines:**
+/// - `text`: General text input
+/// - `email`: Email address with email keyboard
+/// - `password`: Password with obscured text
+/// - `number`: Numeric input with number keyboard
+/// - `phone`: Phone number with phone keyboard
+/// - `url`: URL input with URL keyboard
+/// - `search`: Search input with search keyboard
+/// - `multiline`: Multi-line text area
+///
+/// **Usage:**
+/// ```dart
+/// OsmeaComponents.textField(
+///   type: TextFieldType.email,
+///   label: 'Email Address',
+/// )
+/// ```
+enum TextFieldType {
+  /// 📝 **Text** - General text input
+  /// - Standard text keyboard
+  /// - No special formatting
+  text,
+
+  /// 📧 **Email** - Email address input
+  /// - Email keyboard with @ symbol
+  /// - Email validation support
+  email,
+
+  /// 🔒 **Password** - Password input
+  /// - Obscured text display
+  /// - Security-focused keyboard
+  password,
+
+  /// 🔢 **Number** - Numeric input
+  /// - Number keyboard
+  /// - Numeric validation
+  number,
+
+  /// 📱 **Phone** - Phone number input
+  /// - Phone keyboard
+  /// - Phone formatting support
+  phone,
+
+  /// 🌐 **URL** - URL input
+  /// - URL keyboard with shortcuts
+  /// - URL validation support
+  url,
+
+  /// 🔍 **Search** - Search input
+  /// - Search keyboard
+  /// - Search action button
+  search,
+
+  /// 📄 **Multiline** - Multi-line text area
+  /// - Multiline text input
+  /// - Expanded height support
+  multiline,
+
+  /// 🔢 **OTP** - One-Time Password input
+  /// - Numeric keyboard
+  /// - Single digit input fields
+  /// - Auto-navigation between fields
+  otp,
 }

--- a/packages/components/lib/src/utils/text_field_extensions.dart
+++ b/packages/components/lib/src/utils/text_field_extensions.dart
@@ -1,0 +1,133 @@
+import 'package:flutter/material.dart';
+import 'package:osmea_components/src/enums/components_enum.dart';
+
+/// 📝 **TextField Enum Extensions**
+///
+/// Helper extensions for getting readable names from TextField enums
+
+extension TextFieldSizeExtension on TextFieldSize {
+  String get displayName {
+    switch (this) {
+      case TextFieldSize.extraSmall:
+        return 'Extra Small';
+      case TextFieldSize.small:
+        return 'Small';
+      case TextFieldSize.medium:
+        return 'Medium';
+      case TextFieldSize.large:
+        return 'Large';
+      case TextFieldSize.extraLarge:
+        return 'Extra Large';
+    }
+  }
+}
+
+extension TextFieldVariantExtension on TextFieldVariant {
+  String get displayName {
+    switch (this) {
+      case TextFieldVariant.outlined:
+        return 'Outlined';
+      case TextFieldVariant.filled:
+        return 'Filled';
+      case TextFieldVariant.underlined:
+        return 'Underlined';
+      case TextFieldVariant.borderless:
+        return 'Borderless';
+    }
+  }
+}
+
+extension TextFieldStateExtension on TextFieldState {
+  String get displayName {
+    switch (this) {
+      case TextFieldState.enabled:
+        return 'Enabled';
+      case TextFieldState.disabled:
+        return 'Disabled';
+      case TextFieldState.focused:
+        return 'Focused';
+      case TextFieldState.error:
+        return 'Error';
+      case TextFieldState.success:
+        return 'Success';
+      case TextFieldState.warning:
+        return 'Warning';
+    }
+  }
+}
+
+extension TextFieldTypeExtension on TextFieldType {
+  String get displayName {
+    switch (this) {
+      case TextFieldType.text:
+        return 'Text';
+      case TextFieldType.email:
+        return 'Email';
+      case TextFieldType.password:
+        return 'Password';
+      case TextFieldType.number:
+        return 'Number';
+      case TextFieldType.phone:
+        return 'Phone';
+      case TextFieldType.url:
+        return 'URL';
+      case TextFieldType.search:
+        return 'Search';
+      case TextFieldType.multiline:
+        return 'Multiline';
+      case TextFieldType.otp:
+        return 'OTP';
+    }
+  }
+
+  /// Gets the appropriate TextInputType for this field type
+  TextInputType get keyboardType {
+    switch (this) {
+      case TextFieldType.text:
+      case TextFieldType.search:
+        return TextInputType.text;
+      case TextFieldType.email:
+        return TextInputType.emailAddress;
+      case TextFieldType.password:
+        return TextInputType.visiblePassword;
+      case TextFieldType.number:
+      case TextFieldType.otp:
+        return TextInputType.number;
+      case TextFieldType.phone:
+        return TextInputType.phone;
+      case TextFieldType.url:
+        return TextInputType.url;
+      case TextFieldType.multiline:
+        return TextInputType.multiline;
+    }
+  }
+
+  /// Whether this field type should be obscured
+  bool get isObscureText => this == TextFieldType.password;
+
+  /// Gets the appropriate TextInputAction
+  TextInputAction get inputAction {
+    switch (this) {
+      case TextFieldType.multiline:
+        return TextInputAction.newline;
+      case TextFieldType.search:
+        return TextInputAction.search;
+      case TextFieldType.otp:
+        return TextInputAction.next;
+      default:
+        return TextInputAction.done;
+    }
+  }
+
+  /// Gets the appropriate TextCapitalization
+  TextCapitalization get capitalization {
+    switch (this) {
+      case TextFieldType.multiline:
+        return TextCapitalization.sentences;
+      case TextFieldType.otp:
+        return TextCapitalization.none;
+      default:
+        return TextCapitalization.none;
+    }
+  }
+}

--- a/packages/components/lib/src/utils/text_field_size_extensions.dart
+++ b/packages/components/lib/src/utils/text_field_size_extensions.dart
@@ -1,0 +1,173 @@
+import 'package:flutter/material.dart';
+import 'package:osmea_components/src/enums/components_enum.dart';
+import 'package:osmea_components/src/utils/sizer_extensions.dart';
+import 'package:osmea_components/src/utils/text_extensions.dart';
+import 'package:osmea_components/src/styles/text_style.dart';
+
+/// 📏 **TextField Size Configuration**
+///
+/// Configuration class that holds all size-related properties for text fields.
+/// Used to maintain consistency across different text field sizes.
+
+class TextFieldSizeConfig {
+  const TextFieldSizeConfig({
+    required this.height,
+    required this.padding,
+    required this.fontSize,
+    required this.borderRadius,
+    required this.iconSize,
+    required this.labelSpacing,
+    required this.helperSpacing,
+  });
+
+  /// Minimum height of the text field
+  final double height;
+
+  /// Internal padding of the text field
+  final EdgeInsets padding;
+
+  /// Font size for input text
+  final double fontSize;
+
+  /// Border radius for the text field
+  final BorderRadius borderRadius;
+
+  /// Size of prefix/suffix icons
+  final double iconSize;
+
+  /// Spacing between label and text field
+  final double labelSpacing;
+
+  /// Spacing between text field and helper text
+  final double helperSpacing;
+}
+
+/// 📏 **TextField Size Extensions**
+///
+/// Provides size configurations for different text field sizes.
+/// Uses OSMEA's responsive sizing system from SizerExtension.
+///
+/// **Usage:**
+/// ```dart
+/// final config = TextFieldSize.medium.getConfig(context);
+/// ```
+
+extension TextFieldSizeExtension on TextFieldSize {
+  TextFieldSizeConfig getConfig(BuildContext context) {
+    switch (this) {
+      case TextFieldSize.extraSmall:
+        return TextFieldSizeConfig(
+          height: context.height32,
+          padding: EdgeInsets.symmetric(
+            horizontal: context.spacing8,
+            vertical: context.spacing4,
+          ),
+          fontSize: context.fontSizeSmall,
+          borderRadius: context.borderRadiusLow,
+          iconSize: context.spacing16,
+          labelSpacing: context.spacing4,
+          helperSpacing: context.spacing4,
+        );
+
+      case TextFieldSize.small:
+        return TextFieldSizeConfig(
+          height: context.height40,
+          padding: EdgeInsets.symmetric(
+            horizontal: context.spacing10,
+            vertical: context.spacing6,
+          ),
+          fontSize: context.fontSizeSmall,
+          borderRadius: context.borderRadiusLow,
+          iconSize: context.spacing16,
+          labelSpacing: context.spacing4,
+          helperSpacing: context.spacing4,
+        );
+
+      case TextFieldSize.medium:
+        return TextFieldSizeConfig(
+          height: context.height48,
+          padding: EdgeInsets.symmetric(
+            horizontal: context.spacing12,
+            vertical: context.spacing8,
+          ),
+          fontSize: context.fontSizeMedium,
+          borderRadius: context.borderRadiusNormal,
+          iconSize: context.spacing20,
+          labelSpacing: context.spacing6,
+          helperSpacing: context.spacing4,
+        );
+
+      case TextFieldSize.large:
+        return TextFieldSizeConfig(
+          height: context.height56,
+          padding: EdgeInsets.symmetric(
+            horizontal: context.spacing16,
+            vertical: context.spacing10,
+          ),
+          fontSize: context.fontSizeNormal,
+          borderRadius: context.borderRadiusNormal,
+          iconSize: context.spacing24,
+          labelSpacing: context.spacing6,
+          helperSpacing: context.spacing6,
+        );
+
+      case TextFieldSize.extraLarge:
+        return TextFieldSizeConfig(
+          height: context.height64,
+          padding: EdgeInsets.symmetric(
+            horizontal: context.spacing20,
+            vertical: context.spacing12,
+          ),
+          fontSize: context.fontSizeLarge,
+          borderRadius: context.borderRadiusNormal,
+          iconSize: context.spacing24,
+          labelSpacing: context.spacing8,
+          helperSpacing: context.spacing6,
+        );
+    }
+  }
+
+  /// Get label text style for this size
+  TextStyle getLabelStyle(BuildContext context) {
+    switch (this) {
+      case TextFieldSize.extraSmall:
+      case TextFieldSize.small:
+        return OsmeaTextStyle.labelSmall(context);
+      case TextFieldSize.medium:
+        return OsmeaTextStyle.labelMedium(context);
+      case TextFieldSize.large:
+      case TextFieldSize.extraLarge:
+        return OsmeaTextStyle.labelLarge(context);
+    }
+  }
+
+  /// Get helper text style for this size
+  TextStyle getHelperStyle(BuildContext context) {
+    switch (this) {
+      case TextFieldSize.extraSmall:
+      case TextFieldSize.small:
+        return OsmeaTextStyle.captionSmall(context);
+      case TextFieldSize.medium:
+        return OsmeaTextStyle.captionMedium(context);
+      case TextFieldSize.large:
+        return OsmeaTextStyle.captionLarge(context);
+      case TextFieldSize.extraLarge:
+        return OsmeaTextStyle.bodySmall(context);
+    }
+  }
+
+  /// Get input text style for this size
+  TextStyle getInputStyle(BuildContext context) {
+    switch (this) {
+      case TextFieldSize.extraSmall:
+      case TextFieldSize.small:
+        return OsmeaTextStyle.bodySmall(context);
+      case TextFieldSize.medium:
+        return OsmeaTextStyle.bodyMedium(context);
+      case TextFieldSize.large:
+        return OsmeaTextStyle.bodyLarge(context);
+      case TextFieldSize.extraLarge:
+        return OsmeaTextStyle.titleMedium(context);
+    }
+  }
+}


### PR DESCRIPTION
## 📋 PR Description

This PR introduces a comprehensive and modular text field system including support for OTP inputs. It provides highly configurable, reusable components with state management, controller layers, and showcase examples for easier integration and testing.

#### 🧱 Core Text Field Infrastructure

- `feat: add TextField enums and extensions for size, variant, state, and type`
  - Introduced enums for:
    - `TextFieldSize`
    - `TextFieldVariant`
    - `TextFieldState`
    - `TextFieldType` with the following options:
      - `text` – Standard input  
      - `email` – Email keyboard + validation  
      - `password` – Obscured secure input  
      - `number` – Numeric input with validation  
      - `phone` – Phone number formatting + keyboard  
      - `url` – URL-specific keyboard and validation  
      - `search` – Search input with action support  
      - `multiline` – Expanding multi-line input  
      - `otp` – One-Time Password with auto-focus handling  

- `feat: add CoreTextField widget with comprehensive properties and configuration`
  - Built a base widget that handles shared configurations like decoration, validation, focus, keyboard type, etc.

#### 🔐 OTP & TextField Components

- `feat: add OsmeaOTPTextField and OsmeaTextField components with advanced features and customization options`
  - Created specialized widgets for standard and OTP input fields.

- `feat: add OTPCubit and OTPState for managing OTP input state and behavior`
- `feat: add TextFieldCubit and TextFieldCubitState for managing text field state and interactions`
  - Introduced BLoC-based state management for reactive OTP and TextField handling.

- `feat: add OTPController and OsmeaTextFieldController for enhanced OTP and text field managemen
---

## ✅ Checklist

- [x] Code follows the project standards and guidelines.
- [x] Relevant unit tests are written and all tests are passing.
- [ ] Test coverage is adequate for the changes.
- [x] Any unnecessary files or debug statements have been removed.
- [ ] Documentation is updated where necessary.
- [x] The PR has been reviewed by at least one team member before merging.

---

## 🛠 Steps to Test
1. Navigate to the `TextFieldExample` screen.
2. ✅ Render different `TextFieldType` variants:
   - `text`, `email`, `password`, `number`, `phone`, `url`, `search`, `multiline`
3. ✅ Verify:
   - Correct keyboard type is shown for each variant.
   - Each field applies correct decorations, validation behaviors, and focus handling.
4. ✅ Check responsiveness and padding for `TextFieldSize` values (S, M, L).
5. ✅ Toggle between `TextFieldVariant` (e.g., filled, outlined) and observe correct rendering.


#### 🔐 OTP Text Field

1. Use the `OsmeaOTPTextField` widget in the `TextFieldExample`.
2. ✅ Ensure:
   - Input is restricted to one digit per field.
   - Keyboard type is numeric.
   - Automatic focus moves to the next field upon input.
3. ✅ Test edge behavior:
   - Deletion moves focus backward.
   - Pasting full OTP distributes across fields.
   - Inputs are validated and collected properly in controller/state.


#### 🧠 BLoC / State Management

1. Interact with fields connected to `TextFieldCubit` and `OTPCubit`.
2. ✅ Verify that:
   - State changes reflect in the UI (e.g., error states, loading).
   - External state updates (e.g., reset, auto-fill) work via the cubit/controller logic.
3. ✅ Use `OTPController` or `OsmeaTextFieldController` to programmatically set, reset, or read values.

---

## 🔗 Related Links
- Documentation: https://pub.dev/packages/flutter_bloc
---

### 📷 Screenshots (Optional)
<table>
  <tr>
    <th>Standard Fields</th>
    <th>OTP Input</th>
    <th>Multiline Example</th>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/7e9a4d8a-7245-4e2e-8ffc-fdcf4a4da97d" width="200"/></td>
    <td><img src="https://github.com/user-attachments/assets/31884c86-107e-4dcf-bde4-bd3add4407ce" width="200"/></td>
    <td><img src="https://github.com/user-attachments/assets/ca890409-f7ff-4c2e-a453-ebf0715fc448" width="200"/></td>
  </tr>
</table>

