### PR TITLE
OSMEA - Components -> Loading

### DIFF
--- a/packages/components/example_mobile/lib/loading_example.dart
+++ b/packages/components/example_mobile/lib/loading_example.dart
@@ -108,7 +108,6 @@ class LoadingExample extends StatelessWidget {
         'desc': 'Single dot orbiting.'
       },
     ];
-    final List<double> sizes = [24, 36, 48, 64];
     final List<Color> colors = [
       Colors.blue,
       Colors.red,

--- a/packages/components/example_mobile/lib/loading_example.dart
+++ b/packages/components/example_mobile/lib/loading_example.dart
@@ -1,0 +1,302 @@
+import 'package:flutter/material.dart';
+import 'package:osmea_components/osmea_components.dart';
+
+class LoadingExample extends StatelessWidget {
+  const LoadingExample({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final List<Map<String, dynamic>> loadingTypes = [
+      {
+        'type': LoadingType.rotatingDots,
+        'label': 'Rotating Dots',
+        'desc': 'Circular rotating dots animation.'
+      },
+      {
+        'type': LoadingType.rotatingArcs,
+        'label': 'Rotating Arcs',
+        'desc': 'Spinning arc animation.'
+      },
+      {
+        'type': LoadingType.spiral,
+        'label': 'Spiral',
+        'desc': 'Spiral motion dots.'
+      },
+      {
+        'type': LoadingType.atom,
+        'label': 'Atom',
+        'desc': 'Atom-like orbiting dots.'
+      },
+      {
+        'type': LoadingType.dualRing,
+        'label': 'Dual Ring',
+        'desc': 'Two rings spinning together.'
+      },
+      {
+        'type': LoadingType.circularFade,
+        'label': 'Circular Fade',
+        'desc': 'Classic spinner with fading circle.'
+      },
+      {
+        'type': LoadingType.fadingCircle,
+        'label': 'Fading Circle',
+        'desc': 'Circles fading in and out.'
+      },
+      {
+        'type': LoadingType.dotCircle,
+        'label': 'Dot Circle',
+        'desc': 'Dots arranged in a circle.'
+      },
+      {
+        'type': LoadingType.arcLoader,
+        'label': 'Arc Loader',
+        'desc': 'Rotating arc animation.'
+      },
+      {
+        'type': LoadingType.chasingDots,
+        'label': 'Chasing Dots',
+        'desc': 'Dots chasing each other.'
+      },
+      {
+        'type': LoadingType.bouncingDots,
+        'label': 'Bouncing Dots',
+        'desc': 'Three bouncing dots.'
+      },
+      {
+        'type': LoadingType.tripleBounce,
+        'label': 'Triple Bounce',
+        'desc': 'Three balls bouncing.'
+      },
+      {
+        'type': LoadingType.zigzagDots,
+        'label': 'Zigzag Dots',
+        'desc': 'Dots moving in a zigzag pattern.'
+      },
+      {
+        'type': LoadingType.barWave,
+        'label': 'Bar Wave',
+        'desc': 'Bars moving in a wave.'
+      },
+      {
+        'type': LoadingType.gridPulse,
+        'label': 'Grid Pulse',
+        'desc': 'Grid of pulsing dots.'
+      },
+      {
+        'type': LoadingType.dancingSquares,
+        'label': 'Dancing Squares',
+        'desc': 'Dancing squares animation.'
+      },
+      {
+        'type': LoadingType.dotFlash,
+        'label': 'Dot Flash',
+        'desc': 'Dots flashing in sequence.'
+      },
+      {
+        'type': LoadingType.barLoader,
+        'label': 'Bar Loader',
+        'desc': 'Bars with changing heights.'
+      },
+      {
+        'type': LoadingType.waveBars,
+        'label': 'Wave Bars',
+        'desc': 'Bars moving in a wave pattern.'
+      },
+      {
+        'type': LoadingType.orbitDot,
+        'label': 'Orbit Dot',
+        'desc': 'Single dot orbiting.'
+      },
+    ];
+    final List<double> sizes = [24, 36, 48, 64];
+    final List<Color> colors = [
+      Colors.blue,
+      Colors.red,
+      Colors.green,
+      Colors.orange,
+      Colors.purple,
+      Colors.teal,
+      Colors.pink,
+      Colors.amber,
+      Colors.indigo,
+      Colors.cyan,
+      Colors.deepOrange,
+      Colors.deepPurple,
+      Colors.lightBlue,
+      Colors.lime,
+      Colors.brown,
+      Colors.grey,
+      Colors.blueGrey,
+      Colors.yellow,
+      Colors.lightGreen,
+      Colors.indigoAccent,
+      Colors.redAccent,
+      Colors.greenAccent,
+      Colors.orangeAccent,
+      Colors.purpleAccent,
+      Colors.tealAccent,
+      Colors.pinkAccent,
+      Colors.black,
+      Colors.white,
+      Colors.brown.shade300,
+      Colors.blue.shade900,
+    ];
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('OSMEA Loading Animations')),
+      body: ListView(
+        padding: const EdgeInsets.all(20),
+        children: [
+          Padding(
+            padding: const EdgeInsets.only(bottom: 16),
+            child: Text(
+              'Modern OSMEA Loading Animations',
+              style: Theme.of(context)
+                  .textTheme
+                  .headlineMedium
+                  ?.copyWith(fontWeight: FontWeight.bold),
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.only(bottom: 24),
+            child: Text(
+              'Below you can see all loading animations in the OSMEA library, presented in different sizes and colors. Each animation is shown with a short description and multiple sizes for a modern, clear showcase.',
+              style: Theme.of(context).textTheme.bodyLarge,
+            ),
+          ),
+          for (int i = 0; i < loadingTypes.length; i++)
+            Card(
+              elevation: 3,
+              margin: const EdgeInsets.symmetric(vertical: 12),
+              shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(16)),
+              child: Padding(
+                padding: const EdgeInsets.all(20),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      children: [
+                        Icon(Icons.bubble_chart,
+                            color: colors[i % colors.length], size: 28),
+                        const SizedBox(width: 12),
+                        Text(
+                          loadingTypes[i]['label'],
+                          style: Theme.of(context)
+                              .textTheme
+                              .titleLarge
+                              ?.copyWith(fontWeight: FontWeight.bold),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 8),
+                    Text(
+                      loadingTypes[i]['desc'],
+                      style: Theme.of(context)
+                          .textTheme
+                          .bodyMedium
+                          ?.copyWith(color: Colors.grey[700]),
+                    ),
+                    const SizedBox(height: 16),
+                    Column(
+                      children: [
+                        Row(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          children: [
+                            for (final size in [24.0, 36.0])
+                              Padding(
+                                padding:
+                                    const EdgeInsets.symmetric(horizontal: 8),
+                                child: ClipRect(
+                                  child: Container(
+                                    width: size + 32,
+                                    padding: const EdgeInsets.symmetric(
+                                        vertical: 10),
+                                    decoration: BoxDecoration(
+                                      color: colors[i % colors.length]
+                                          .withOpacity(0.08),
+                                      borderRadius: BorderRadius.circular(12),
+                                    ),
+                                    child: Column(
+                                      mainAxisSize: MainAxisSize.min,
+                                      children: [
+                                        FittedBox(
+                                          fit: BoxFit.scaleDown,
+                                          child: OsmeaComponents.loading(
+                                            type: loadingTypes[i]['type'],
+                                            size: size,
+                                            color: colors[i % colors.length],
+                                          ),
+                                        ),
+                                        const SizedBox(height: 8),
+                                        Text(
+                                          '${size.toInt()} px',
+                                          style: Theme.of(context)
+                                              .textTheme
+                                              .bodySmall
+                                              ?.copyWith(
+                                                  fontWeight: FontWeight.w500),
+                                        ),
+                                      ],
+                                    ),
+                                  ),
+                                ),
+                              ),
+                          ],
+                        ),
+                        const SizedBox(height: 12),
+                        Row(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          children: [
+                            for (final size in [48.0, 64.0])
+                              Padding(
+                                padding:
+                                    const EdgeInsets.symmetric(horizontal: 8),
+                                child: ClipRect(
+                                  child: Container(
+                                    width: size + 32,
+                                    padding: const EdgeInsets.symmetric(
+                                        vertical: 10),
+                                    decoration: BoxDecoration(
+                                      color: colors[i % colors.length]
+                                          .withOpacity(0.08),
+                                      borderRadius: BorderRadius.circular(12),
+                                    ),
+                                    child: Column(
+                                      mainAxisSize: MainAxisSize.min,
+                                      children: [
+                                        FittedBox(
+                                          fit: BoxFit.scaleDown,
+                                          child: OsmeaComponents.loading(
+                                            type: loadingTypes[i]['type'],
+                                            size: size,
+                                            color: colors[i % colors.length],
+                                          ),
+                                        ),
+                                        const SizedBox(height: 8),
+                                        Text(
+                                          '${size.toInt()} px',
+                                          style: Theme.of(context)
+                                              .textTheme
+                                              .bodySmall
+                                              ?.copyWith(
+                                                  fontWeight: FontWeight.w500),
+                                        ),
+                                      ],
+                                    ),
+                                  ),
+                                ),
+                              ),
+                          ],
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}

--- a/packages/components/example_mobile/lib/main.dart
+++ b/packages/components/example_mobile/lib/main.dart
@@ -3,6 +3,7 @@ import 'package:osmea_components/osmea_components.dart';
 import 'package:osmea_components_example/align_example.dart';
 import 'package:osmea_components_example/carousel_example.dart';
 import 'package:osmea_components_example/chips_example.dart';
+import 'package:osmea_components_example/loading_example.dart';
 import 'package:osmea_components_example/services/mock_auth_service.dart';
 import 'package:osmea_components_example/center_example.dart';
 import 'package:osmea_components_example/appbars_demo.dart';
@@ -255,6 +256,17 @@ class ComponentsScreen extends StatelessWidget {
                     context,
                     MaterialPageRoute(
                       builder: (context) => const ButtonExample(),
+                    ),
+                  ),
+                ),
+                _buildComponentCard(
+                  context,
+                  'loading',
+                  Icons.animation,
+                  () => Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (context) => const LoadingExample(),
                     ),
                   ),
                 ),

--- a/packages/components/lib/osmea_components.dart
+++ b/packages/components/lib/osmea_components.dart
@@ -49,7 +49,6 @@ export 'src/utils/chips_extensions.dart';
 export 'src/utils/carousel_extensions.dart';
 export 'src/utils/list_item_extensions.dart';
 
-
 // Central export for all components
 export 'src/components.dart';
 
@@ -61,3 +60,7 @@ export 'src/components/login_button/cubit/login_button_cubit.dart';
 export 'src/core/cubit_button/cubit/core_button_state.dart';
 export 'src/core/cubit_button/cubit/core_button_cubit.dart';
 
+// Loading
+export 'src/utils/loading_extensions.dart';
+export 'src/components/loading/cubit/loading_cubit.dart';
+export 'src/components/loading/cubit/loading_state.dart';

--- a/packages/components/lib/src/components.dart
+++ b/packages/components/lib/src/components.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/gestures.dart';
+import 'package:osmea_components/osmea_components.dart';
 
 // Component imports
 import 'package:osmea_components/src/components/align/align.dart';

--- a/packages/components/lib/src/components.dart
+++ b/packages/components/lib/src/components.dart
@@ -12,6 +12,7 @@ import 'package:osmea_components/src/components/checkbox/checkbox.dart';
 import 'package:osmea_components/src/components/chips/chips.dart';
 import 'package:osmea_components/src/components/column/column.dart';
 import 'package:osmea_components/src/components/container/container.dart';
+import 'package:osmea_components/src/components/loading/cubit/loading_cubit.dart';
 import 'package:osmea_components/src/components/login_button/cubit/login_button_cubit.dart';
 import 'package:osmea_components/src/components/login_button/login_button.dart';
 import 'package:osmea_components/src/components/navbar/navbar.dart';
@@ -31,6 +32,7 @@ import 'package:osmea_components/src/theme/theme.dart';
 import 'package:osmea_components/src/components/text/text.dart';
 import 'package:osmea_components/src/components/carousel/carousel.dart';
 import 'package:osmea_components/src/components/list_item/list_item.dart';
+import 'package:osmea_components/src/utils/loading_extensions.dart';
 
 import 'enums/enums.dart';
 
@@ -1770,6 +1772,21 @@ class OsmeaComponents {
       collapseIcon: collapseIcon,
       expandIcon: expandIcon,
     );
+  }
+
+  /// 🌀 **OSMEA Loading** - Modern loading spinner/bar component
+  ///
+  /// Example:
+  /// ```dart
+  /// OsmeaComponents.loading(type: LoadingType.circularFade, size: 48)
+  /// ```
+  static Widget loading({
+    required LoadingType type,
+    double size = 32,
+    Color? color,
+    LoadingCubit? cubit,
+  }) {
+    return type.osmeaLoading(size: size, color: color, cubit: cubit);
   }
 }
 

--- a/packages/components/lib/src/components/loading/cubit/loading_cubit.dart
+++ b/packages/components/lib/src/components/loading/cubit/loading_cubit.dart
@@ -1,0 +1,71 @@
+/// 🔄 OSMEA Loading Cubit
+///
+/// Copyright (c) 2025, OSMEA Team
+/// https://github.com/masterfabric-mobile/osmea/tree/dev/packages/components
+///
+/// Cubit for managing loading animation state and progress.
+///
+/// {@category Cubit}
+/// {@subCategory Loading}
+///
+/// Example usage:
+/// ```dart
+/// final cubit = LoadingCubit(type: LoadingType.rotatingDots, size: 36);
+/// ```
+
+import 'dart:async';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:osmea_components/src/components/loading/cubit/loading_state.dart';
+import '../../../enums/loading_enums.dart';
+
+/// Manages the state and animation progress for loading indicators.
+class LoadingCubit extends Cubit<LoadingState> {
+  Timer? _timer;
+  static const _tickDuration = Duration(milliseconds: 16); // ~60fps
+
+  /// Creates a LoadingCubit with optional type, size, color, and visibility.
+  LoadingCubit({
+    LoadingType? type,
+    double? size,
+    Color? color,
+    bool? visible,
+  }) : super(LoadingState(
+          type: type ?? LoadingType.circularFade,
+          size: size ?? 36,
+          color: color,
+          visible: visible ?? true,
+        )) {
+    _startTicker();
+  }
+
+  /// Starts the animation ticker for progress updates.
+  void _startTicker() {
+    _timer?.cancel();
+    _timer = Timer.periodic(_tickDuration, (timer) {
+      final next = (state.progress + 0.01) % 1.0;
+      emit(state.copyWith(progress: next));
+    });
+  }
+
+  /// Sets the loading animation type.
+  void setType(LoadingType type) => emit(state.copyWith(type: type));
+
+  /// Sets the loading indicator size.
+  void setSize(double size) => emit(state.copyWith(size: size));
+
+  /// Sets the loading indicator color.
+  void setColor(Color color) => emit(state.copyWith(color: color));
+
+  /// Shows the loading indicator.
+  void show() => emit(state.copyWith(visible: true));
+
+  /// Hides the loading indicator.
+  void hide() => emit(state.copyWith(visible: false));
+
+  @override
+  Future<void> close() {
+    _timer?.cancel();
+    return super.close();
+  }
+}

--- a/packages/components/lib/src/components/loading/cubit/loading_state.dart
+++ b/packages/components/lib/src/components/loading/cubit/loading_state.dart
@@ -1,0 +1,59 @@
+/// 🔄 OSMEA Loading State
+///
+/// Copyright (c) 2025, OSMEA Team
+/// https://github.com/masterfabric-mobile/osmea/tree/dev/packages/components
+///
+/// State class for loading animation configuration and progress.
+///
+/// {@category State}
+/// {@subCategory Loading}
+///
+/// Example usage:
+/// ```dart
+/// final state = LoadingState(type: LoadingType.rotatingDots, size: 36);
+/// ```
+
+import 'package:flutter/material.dart';
+import 'package:osmea_components/osmea_components.dart';
+
+/// Holds the configuration and progress for a loading animation.
+class LoadingState {
+  /// The type of loading animation.
+  final LoadingType type;
+
+  /// The size of the loading indicator.
+  final double size;
+
+  /// The color of the loading indicator.
+  final Color? color;
+
+  /// Whether the loading indicator is visible.
+  final bool visible;
+
+  /// The current animation progress (0.0 - 1.0).
+  final double progress;
+
+  LoadingState({
+    required this.type,
+    this.size = 32,
+    this.color,
+    this.visible = true,
+    this.progress = 0.0,
+  });
+
+  /// Returns a copy of this state with updated fields.
+  LoadingState copyWith({
+    LoadingType? type,
+    double? size,
+    Color? color,
+    bool? visible,
+    double? progress,
+  }) =>
+      LoadingState(
+        type: type ?? this.type,
+        size: size ?? this.size,
+        color: color ?? this.color,
+        visible: visible ?? this.visible,
+        progress: progress ?? this.progress,
+      );
+}

--- a/packages/components/lib/src/components/loading/loading.dart
+++ b/packages/components/lib/src/components/loading/loading.dart
@@ -1,0 +1,1249 @@
+// ignore_for_file: unused_element
+
+import 'dart:math';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:osmea_components/src/components/align/align.dart';
+import 'package:osmea_components/src/components/center/center.dart';
+import 'package:osmea_components/src/components/column/column.dart';
+import 'package:osmea_components/src/components/container/container.dart';
+import 'package:osmea_components/src/components/row/row.dart';
+import 'package:osmea_components/src/components/sized_box/sized_box.dart';
+import 'package:osmea_components/src/core/container_widget.dart';
+import 'package:osmea_components/src/utils/sizer_extensions.dart';
+import '../../enums/loading_enums.dart';
+import 'cubit/loading_cubit.dart';
+import 'cubit/loading_state.dart';
+import '../../styles/colors.dart';
+
+class CoreLoadingWidget extends CoreContainer {
+  final LoadingCubit cubit;
+
+  const CoreLoadingWidget({
+    required this.cubit,
+    super.key,
+    super.width,
+    super.height,
+    super.color,
+    super.decoration,
+    super.padding,
+    super.margin,
+    super.alignment,
+    super.constraints,
+    super.transform,
+    super.transformAlignment,
+    super.foregroundDecoration,
+    super.clipBehavior,
+    super.child,
+    super.customTheme,
+  });
+
+  @override
+  Widget buildWidget(BuildContext context) {
+    return BlocBuilder<LoadingCubit, LoadingState>(
+      bloc: cubit,
+      builder: (context, state) {
+        if (!state.visible) return const SizedBox.shrink();
+        switch (state.type) {
+          case LoadingType.circularFade:
+            return _buildCircularFade(state.size, state.color);
+          case LoadingType.bouncingDots:
+            return _buildBouncingDots(state.size, state.color, state.progress);
+          case LoadingType.waveBars:
+            return _buildWaveBars(state.size, state.color, state.progress);
+          case LoadingType.chasingDots:
+            return _buildChasingDots(state.size, state.color, state.progress);
+          case LoadingType.dualRing:
+            return _buildDualRing(state.size, state.color, state.progress);
+          case LoadingType.zigzagDots:
+            return _buildZigzagDots(state.size, state.color, state.progress);
+          case LoadingType.tripleBounce:
+            return _buildTripleBounce(state.size, state.color, state.progress);
+          case LoadingType.dotCircle:
+            return _buildDotCircle(state.size, state.color, state.progress);
+          case LoadingType.barLoader:
+            return _buildBarLoader(state.size, state.color, state.progress);
+          case LoadingType.fadingCircle:
+            return _buildFadingCircle(state.size, state.color, state.progress);
+          case LoadingType.rotatingDots:
+            return _buildRotatingDots(state.size, state.color, state.progress);
+          case LoadingType.dancingSquares:
+            return _buildDancingSquares(
+                state.size, state.color, state.progress);
+          case LoadingType.orbitDot:
+            return _buildOrbitDot(state.size, state.color, state.progress);
+          case LoadingType.spiral:
+            return _buildSpiral(state.size, state.color, state.progress);
+          case LoadingType.rotatingArcs:
+            return _buildRotatingArcs(state.size, state.color, state.progress);
+          case LoadingType.gridPulse:
+            return _buildGridPulse(state.size, state.color, state.progress);
+          case LoadingType.arcLoader:
+            return _buildArcLoader(state.size, state.color, state.progress);
+          case LoadingType.dotFlash:
+            return _buildDotFlash(state.size, state.color, state.progress);
+          case LoadingType.barWave:
+            return _buildBarWave(state.size, state.color, state.progress);
+          case LoadingType.atom:
+            return _buildAtom(state.size, state.color, state.progress);
+          default:
+            return _buildCircularFade(state.size, state.color);
+        }
+      },
+    );
+  }
+
+  Widget _buildCircularFade(double size, Color? color) {
+    final c = color ?? OsmeaColors.nordicBlue;
+    return OsmeaSizedBox(
+      width: size,
+      height: size,
+      child: CircularProgressIndicator(
+        strokeWidth: size * 0.12,
+        valueColor:
+            AlwaysStoppedAnimation<Color>(c.withAlpha((0.8 * 255).round())),
+        backgroundColor: c.withAlpha((0.2 * 255).round()),
+      ),
+    );
+  }
+
+  Widget _buildBouncingDots(double size, Color? color,
+      [double progress = 0.0]) {
+    final c = color ?? OsmeaColors.nordicBlue;
+    return _BouncingDotsLoading(size: size, color: c, progress: progress);
+  }
+
+  Widget _buildWaveBars(double size, Color? color, [double progress = 0.0]) {
+    final c = color ?? OsmeaColors.nordicBlue;
+    return _WaveBarsLoading(size: size, color: c, progress: progress);
+  }
+
+  Widget _buildChasingDots(double size, Color? color, double progress) {
+    final c = color ?? OsmeaColors.nordicBlue;
+    return _ChasingDotsLoading(size: size, color: c, progress: progress);
+  }
+
+  Widget _buildDualRing(double size, Color? color, double progress) {
+    final c = color ?? OsmeaColors.nordicBlue;
+    return _DualRingLoading(size: size, color: c, progress: progress);
+  }
+
+  Widget _buildZigzagDots(double size, Color? color, double progress) {
+    final c = color ?? OsmeaColors.nordicBlue;
+    return _ZigzagDotsLoading(size: size, color: c, progress: progress);
+  }
+
+  Widget _buildTripleBounce(double size, Color? color, double progress) {
+    final c = color ?? OsmeaColors.nordicBlue;
+    return _TripleBounceLoading(size: size, color: c, progress: progress);
+  }
+
+  Widget _buildDotCircle(double size, Color? color, double progress) {
+    final c = color ?? OsmeaColors.nordicBlue;
+    return _DotCircleLoading(size: size, color: c, progress: progress);
+  }
+
+  Widget _buildBarLoader(double size, Color? color, double progress) {
+    final c = color ?? OsmeaColors.nordicBlue;
+    return _BarLoaderLoading(size: size, color: c, progress: progress);
+  }
+
+  Widget _buildFadingCircle(double size, Color? color, double progress) {
+    final c = color ?? OsmeaColors.nordicBlue;
+    return _FadingCircleLoading(size: size, color: c, progress: progress);
+  }
+
+  Widget _buildRotatingDots(double size, Color? color, double progress) {
+    final c = color ?? OsmeaColors.nordicBlue;
+    return _RotatingDotsLoading(size: size, color: c, progress: progress);
+  }
+
+  Widget _buildDancingSquares(double size, Color? color, double progress) {
+    final c = color ?? OsmeaColors.nordicBlue;
+    return _DancingSquaresLoading(size: size, color: c, progress: progress);
+  }
+
+  Widget _buildOrbitDot(double size, Color? color, double progress) {
+    final c = color ?? OsmeaColors.nordicBlue;
+    return _OrbitDotLoading(size: size, color: c, progress: progress);
+  }
+
+  Widget _buildSpiral(double size, Color? color, double progress) {
+    final c = color ?? OsmeaColors.nordicBlue;
+    return _SpiralLoading(size: size, color: c, progress: progress);
+  }
+
+  Widget _buildRotatingArcs(double size, Color? color, double progress) {
+    final c = color ?? OsmeaColors.nordicBlue;
+    return _RotatingArcsLoading(size: size, color: c, progress: progress);
+  }
+
+  Widget _buildJumpingBall(double size, Color? color, double progress) {
+    final c = color ?? OsmeaColors.nordicBlue;
+    return _JumpingBallLoading(size: size, color: c, progress: progress);
+  }
+
+  Widget _buildGridPulse(double size, Color? color, double progress) {
+    final c = color ?? OsmeaColors.nordicBlue;
+    return _GridPulseLoading(size: size, color: c, progress: progress);
+  }
+
+  Widget _buildArcLoader(double size, Color? color, double progress) {
+    final c = color ?? OsmeaColors.nordicBlue;
+    return _ArcLoaderLoading(size: size, color: c, progress: progress);
+  }
+
+  Widget _buildDotFlash(double size, Color? color, double progress) {
+    final c = color ?? OsmeaColors.nordicBlue;
+    return _DotFlashLoading(size: size, color: c, progress: progress);
+  }
+
+  Widget _buildBarWave(double size, Color? color, double progress) {
+    final c = color ?? OsmeaColors.nordicBlue;
+    return _BarWaveLoading(size: size, color: c, progress: progress);
+  }
+
+  Widget _buildAtom(double size, Color? color, double progress) {
+    final c = color ?? OsmeaColors.nordicBlue;
+    return _AtomLoading(size: size, color: c, progress: progress);
+  }
+}
+
+class _BouncingDotsLoading extends StatelessWidget {
+  final double size;
+  final Color color;
+  final double progress;
+  const _BouncingDotsLoading(
+      {Key? key,
+      required this.size,
+      required this.color,
+      required this.progress})
+      : super(key: key);
+  @override
+  Widget build(BuildContext context) {
+    const count = 3;
+    final dotWidth = size / (count * 1.4);
+    final margin = size / (count * 7);
+    return OsmeaSizedBox(
+      width: size,
+      height: size * 0.5,
+      child: OsmeaRow(
+        mainAxisAlignment: centerMain,
+        children: List.generate(count, (i) {
+          final t = ((progress + i * 0.2) % 1.0);
+          final y = -size * 0.15 * sin(t * pi);
+          return Transform.translate(
+            offset: Offset(0, y),
+            child: OsmeaContainer(
+              width: dotWidth,
+              height: dotWidth,
+              margin: EdgeInsets.symmetric(horizontal: margin),
+              decoration: BoxDecoration(color: color, shape: BoxShape.circle),
+            ),
+          );
+        }),
+      ),
+    );
+  }
+}
+
+class _WaveBarsLoading extends StatelessWidget {
+  final double size;
+  final Color color;
+  final double progress;
+  const _WaveBarsLoading(
+      {Key? key, this.size = 32, required this.color, required this.progress})
+      : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    const barCount = 5;
+    return SizedBox(
+      width: size,
+      height: size * 0.6,
+      child: OsmeaRow(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: List.generate(barCount, (i) {
+          final delay = i * 0.1;
+          final t = ((progress + delay) % 1.0);
+          final scale = 0.5 + 0.5 * (1 - (t - 0.5).abs() * 2);
+          return Transform.scale(
+            scale: scale,
+            child: OsmeaContainer(
+              width: size * 0.12,
+              height: size * 0.5,
+              margin: EdgeInsets.symmetric(horizontal: size * 0.03),
+              decoration: BoxDecoration(
+                color: color,
+                borderRadius: BorderRadius.circular(4),
+              ),
+            ),
+          );
+        }),
+      ),
+    );
+  }
+}
+
+class _ChasingDotsLoading extends StatefulWidget {
+  final double size;
+  final Color color;
+  final double progress;
+  const _ChasingDotsLoading(
+      {Key? key, this.size = 32, required this.color, required this.progress})
+      : super(key: key);
+  @override
+  State<_ChasingDotsLoading> createState() => _ChasingDotsLoadingState();
+}
+
+class _ChasingDotsLoadingState extends State<_ChasingDotsLoading>
+    with SingleTickerProviderStateMixin {
+  late AnimationController _controller;
+  @override
+  void initState() {
+    super.initState();
+    _controller =
+        AnimationController(vsync: this, duration: context.animationMedium)
+          ..repeat();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return OsmeaSizedBox(
+      width: widget.size,
+      height: widget.size,
+      child: AnimatedBuilder(
+        animation: _controller,
+        builder: (context, child) {
+          final angle = _controller.value * 6.28319;
+          return Stack(
+            alignment: center,
+            children: [
+              Transform.translate(
+                offset: Offset(widget.size * 0.35 * cos(angle),
+                    widget.size * 0.35 * sin(angle)),
+                child: _dot(
+                    widget.size, widget.color.withAlpha((0.7 * 255).round())),
+              ),
+              Transform.translate(
+                offset: Offset(widget.size * 0.35 * cos(angle + 3.14159),
+                    widget.size * 0.35 * sin(angle + 3.14159)),
+                child: _dot(
+                    widget.size, widget.color.withAlpha((0.3 * 255).round())),
+              ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _dot(double size, Color color) => OsmeaContainer(
+        width: size * 0.22,
+        height: size * 0.22,
+        decoration: BoxDecoration(color: color, shape: BoxShape.circle),
+      );
+}
+
+class _DualRingLoading extends StatefulWidget {
+  final double size;
+  final Color color;
+  final double progress;
+  const _DualRingLoading(
+      {Key? key, this.size = 32, required this.color, required this.progress})
+      : super(key: key);
+  @override
+  State<_DualRingLoading> createState() => _DualRingLoadingState();
+}
+
+class _DualRingLoadingState extends State<_DualRingLoading>
+    with SingleTickerProviderStateMixin {
+  late AnimationController _controller;
+  @override
+  void initState() {
+    super.initState();
+    _controller =
+        AnimationController(vsync: this, duration: context.animationMedium)
+          ..repeat();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return OsmeaSizedBox(
+      width: widget.size,
+      height: widget.size,
+      child: AnimatedBuilder(
+        animation: _controller,
+        builder: (context, child) {
+          return Stack(
+            alignment: Alignment.center,
+            children: [
+              Transform.rotate(
+                angle: _controller.value * 6.28319,
+                child: CustomPaint(
+                  size: Size(widget.size, widget.size),
+                  painter: _RingPainter(
+                      widget.color.withAlpha((0.7 * 255).round()), 0.8),
+                ),
+              ),
+              Transform.rotate(
+                angle: -_controller.value * 6.28319,
+                child: CustomPaint(
+                  size: Size(widget.size * 0.7, widget.size * 0.7),
+                  painter: _RingPainter(
+                      widget.color.withAlpha((0.3 * 255).round()), 0.6),
+                ),
+              ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _RingPainter extends CustomPainter {
+  final Color color;
+  final double thickness;
+  _RingPainter(this.color, this.thickness);
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint()
+      ..color = color
+      ..strokeWidth = size.width * 0.12 * thickness
+      ..style = PaintingStyle.stroke
+      ..strokeCap = StrokeCap.round;
+    canvas.drawArc(
+      Rect.fromLTWH(0, 0, size.width, size.height),
+      0,
+      3.14159 * 1.5,
+      false,
+      paint,
+    );
+  }
+
+  @override
+  bool shouldRepaint(covariant CustomPainter oldDelegate) => false;
+}
+
+class _ZigzagDotsLoading extends StatelessWidget {
+  final double size;
+  final Color color;
+  final double progress;
+  const _ZigzagDotsLoading(
+      {Key? key,
+      required this.size,
+      required this.color,
+      required this.progress})
+      : super(key: key);
+  @override
+  Widget build(BuildContext context) {
+    const count = 5;
+    final dotWidth = size / (count * 1.4);
+    final margin = size / (count * 7);
+    return OsmeaSizedBox(
+      width: size,
+      height: size * 0.5,
+      child: OsmeaRow(
+        mainAxisAlignment: centerMain,
+        children: List.generate(count, (i) {
+          final t = ((progress + i * 0.15) % 1.0);
+          final y =
+              (i.isEven ? -1 : 1) * (size * 0.15) * (0.5 - (t - 0.5).abs());
+          return Transform.translate(
+            offset: Offset(0, y),
+            child: OsmeaContainer(
+              width: dotWidth,
+              height: dotWidth,
+              margin: EdgeInsets.symmetric(horizontal: margin),
+              decoration: BoxDecoration(color: color, shape: BoxShape.circle),
+            ),
+          );
+        }),
+      ),
+    );
+  }
+}
+
+class _TripleBounceLoading extends StatelessWidget {
+  final double size;
+  final Color color;
+  final double progress;
+  const _TripleBounceLoading(
+      {Key? key,
+      required this.size,
+      required this.color,
+      required this.progress})
+      : super(key: key);
+  @override
+  Widget build(BuildContext context) {
+    const count = 3;
+    final dotWidth = size / (count * 1.4);
+    final margin = size / (count * 7);
+    return SizedBox(
+      width: size,
+      height: size * 0.5,
+      child: OsmeaRow(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: List.generate(count, (i) {
+          final t = ((progress + i * 0.2) % 1.0);
+          final scale = 0.5 + 0.5 * sin(t * pi);
+          return Transform.scale(
+            scale: scale,
+            child: OsmeaContainer(
+              width: dotWidth,
+              height: dotWidth,
+              margin: EdgeInsets.symmetric(horizontal: margin),
+              decoration: BoxDecoration(color: color, shape: BoxShape.circle),
+            ),
+          );
+        }),
+      ),
+    );
+  }
+}
+
+class _DotCircleLoading extends StatelessWidget {
+  final double size;
+  final Color color;
+  final double progress;
+  const _DotCircleLoading(
+      {Key? key,
+      required this.size,
+      required this.color,
+      required this.progress})
+      : super(key: key);
+  @override
+  Widget build(BuildContext context) {
+    const count = 10;
+    return OsmeaSizedBox(
+      width: size,
+      height: size,
+      child: Stack(
+        alignment: center,
+        children: List.generate(count, (i) {
+          final angle = 2 * pi * i / count;
+          final t = ((progress + i / count) % 1.0);
+          final scale = 0.5 + 0.5 * t;
+          return Transform.translate(
+            offset: Offset(size * 0.38 * cos(angle), size * 0.38 * sin(angle)),
+            child: Transform.scale(
+              scale: scale,
+              child: OsmeaContainer(
+                width: size * 0.11,
+                height: size * 0.11,
+                decoration: BoxDecoration(color: color, shape: BoxShape.circle),
+              ),
+            ),
+          );
+        }),
+      ),
+    );
+  }
+}
+
+class _BarLoaderLoading extends StatelessWidget {
+  final double size;
+  final Color color;
+  final double progress;
+  const _BarLoaderLoading(
+      {Key? key,
+      required this.size,
+      required this.color,
+      required this.progress})
+      : super(key: key);
+  @override
+  Widget build(BuildContext context) {
+    const barCount = 6;
+    final barWidth = size / (barCount * 2.2);
+    final margin = size / (barCount * 7);
+    return OsmeaSizedBox(
+      width: size,
+      height: size * 0.3,
+      child: OsmeaRow(
+        mainAxisAlignment: centerMain,
+        children: List.generate(barCount, (i) {
+          final t = ((progress + i * 0.12) % 1.0);
+          final h = size * 0.18 + size * 0.12 * t;
+          return OsmeaContainer(
+            width: barWidth,
+            height: h,
+            margin: EdgeInsets.symmetric(horizontal: margin),
+            decoration: BoxDecoration(
+                color: color, borderRadius: context.borderRadiusLow),
+          );
+        }),
+      ),
+    );
+  }
+}
+
+class _FadingCircleLoading extends StatelessWidget {
+  final double size;
+  final Color color;
+  final double progress;
+  const _FadingCircleLoading(
+      {Key? key,
+      required this.size,
+      required this.color,
+      required this.progress})
+      : super(key: key);
+  @override
+  Widget build(BuildContext context) {
+    const count = 12;
+    return OsmeaSizedBox(
+      width: size,
+      height: size,
+      child: Stack(
+        alignment: Alignment.center,
+        children: List.generate(count, (i) {
+          final angle = 2 * pi * i / count;
+          final t = ((progress + i / count) % 1.0);
+          final opacity = 0.2 + 0.8 * t;
+          return Transform.translate(
+            offset: Offset(size * 0.38 * cos(angle), size * 0.38 * sin(angle)),
+            child: Opacity(
+              opacity: opacity,
+              child: OsmeaContainer(
+                width: size * 0.11,
+                height: size * 0.11,
+                decoration: BoxDecoration(color: color, shape: BoxShape.circle),
+              ),
+            ),
+          );
+        }),
+      ),
+    );
+  }
+}
+
+class _RotatingDotsLoading extends StatelessWidget {
+  final double size;
+  final Color color;
+  final double progress;
+  const _RotatingDotsLoading(
+      {Key? key,
+      required this.size,
+      required this.color,
+      required this.progress})
+      : super(key: key);
+  @override
+  Widget build(BuildContext context) {
+    const count = 8;
+    return OsmeaSizedBox(
+      width: size,
+      height: size,
+      child: Stack(
+        alignment: center,
+        children: List.generate(count, (i) {
+          final angle = 2 * pi * i / count + progress * 2 * pi;
+          return Transform.translate(
+            offset: Offset(size * 0.38 * cos(angle), size * 0.38 * sin(angle)),
+            child: OsmeaContainer(
+              width: size * 0.13,
+              height: size * 0.13,
+              decoration: BoxDecoration(color: color, shape: BoxShape.circle),
+            ),
+          );
+        }),
+      ),
+    );
+  }
+}
+
+class _DancingSquaresLoading extends StatelessWidget {
+  final double size;
+  final Color color;
+  final double progress;
+  const _DancingSquaresLoading(
+      {Key? key,
+      required this.size,
+      required this.color,
+      required this.progress})
+      : super(key: key);
+  @override
+  Widget build(BuildContext context) {
+    const count = 4;
+    final squareWidth = size / (count * 1.4);
+    final margin = size / (count * 7);
+    return OsmeaSizedBox(
+      width: size,
+      height: size * 0.5,
+      child: OsmeaRow(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: List.generate(count, (i) {
+          final t = ((progress + i * 0.18) % 1.0);
+          final scale = 0.7 + 0.3 * sin(t * 2 * pi);
+          return Transform.scale(
+            scale: scale,
+            child: OsmeaContainer(
+              width: squareWidth,
+              height: squareWidth,
+              margin: EdgeInsets.symmetric(horizontal: margin),
+              decoration: BoxDecoration(
+                color: color,
+                borderRadius: context.borderRadiusLow,
+              ),
+            ),
+          );
+        }),
+      ),
+    );
+  }
+}
+
+class _OrbitDotLoading extends StatelessWidget {
+  final double size;
+  final Color color;
+  final double progress;
+  const _OrbitDotLoading(
+      {Key? key,
+      required this.size,
+      required this.color,
+      required this.progress})
+      : super(key: key);
+  @override
+  Widget build(BuildContext context) {
+    return OsmeaSizedBox(
+      width: size,
+      height: size,
+      child: Stack(
+        alignment: center,
+        children: [
+          Opacity(
+            opacity: 0.2,
+            child: OsmeaContainer(
+              width: size * 0.8,
+              height: size * 0.8,
+              decoration: BoxDecoration(
+                border: Border.all(color: color, width: size * 0.07),
+                shape: BoxShape.circle,
+              ),
+            ),
+          ),
+          Transform.rotate(
+            angle: progress * 2 * pi,
+            child: OsmeaAlign(
+              alignment: topCenter,
+              child: OsmeaContainer(
+                width: size * 0.18,
+                height: size * 0.18,
+                decoration: BoxDecoration(color: color, shape: BoxShape.circle),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SpiralLoading extends StatelessWidget {
+  final double size;
+  final Color color;
+  final double progress;
+  const _SpiralLoading(
+      {Key? key,
+      required this.size,
+      required this.color,
+      required this.progress})
+      : super(key: key);
+  @override
+  Widget build(BuildContext context) {
+    const count = 12;
+    return OsmeaSizedBox(
+      width: size,
+      height: size,
+      child: Stack(
+        alignment: center,
+        children: List.generate(count, (i) {
+          final t = ((progress + i / count) % 1.0);
+          final angle = 2 * pi * i / count + t * 2 * pi;
+          final r = size * 0.15 + size * 0.25 * t;
+          return Transform.translate(
+            offset: Offset(r * cos(angle), r * sin(angle)),
+            child: OsmeaContainer(
+              width: size * 0.09,
+              height: size * 0.09,
+              decoration: BoxDecoration(color: color, shape: BoxShape.circle),
+            ),
+          );
+        }),
+      ),
+    );
+  }
+}
+
+class _RotatingArcsLoading extends StatelessWidget {
+  final double size;
+  final Color color;
+  final double progress;
+  const _RotatingArcsLoading(
+      {Key? key,
+      required this.size,
+      required this.color,
+      required this.progress})
+      : super(key: key);
+  @override
+  Widget build(BuildContext context) {
+    return OsmeaSizedBox(
+      width: size,
+      height: size,
+      child: CustomPaint(
+        size: Size(size, size),
+        painter: _RotatingArcsPainter(color, progress),
+      ),
+    );
+  }
+}
+
+class _RotatingArcsPainter extends CustomPainter {
+  final Color color;
+  final double progress;
+  _RotatingArcsPainter(this.color, this.progress);
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint()
+      ..color = color
+      ..strokeWidth = size.width * 0.13
+      ..style = PaintingStyle.stroke
+      ..strokeCap = StrokeCap.round;
+    for (int i = 0; i < 2; i++) {
+      final start = (progress + i * 0.5) * 2 * pi;
+      canvas.drawArc(
+        Rect.fromLTWH(0, 0, size.width, size.height),
+        start,
+        pi / 1.5,
+        false,
+        paint,
+      );
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant CustomPainter oldDelegate) => true;
+}
+
+class _JumpingBallLoading extends StatelessWidget {
+  final double size;
+  final Color color;
+  final double progress;
+  const _JumpingBallLoading(
+      {Key? key,
+      required this.size,
+      required this.color,
+      required this.progress})
+      : super(key: key);
+  @override
+  Widget build(BuildContext context) {
+    final t = (progress % 1.0);
+    final y = -size * 0.25 * sin(t * pi);
+    return OsmeaSizedBox(
+      width: size,
+      height: size * 0.7,
+      child: OsmeaAlign(
+        alignment: Alignment.bottomCenter,
+        child: Transform.translate(
+          offset: Offset(0, y),
+          child: OsmeaContainer(
+            width: size * 0.22,
+            height: size * 0.22,
+            decoration: BoxDecoration(color: color, shape: BoxShape.circle),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _GridPulseLoading extends StatelessWidget {
+  final double size;
+  final Color color;
+  final double progress;
+  const _GridPulseLoading(
+      {Key? key,
+      required this.size,
+      required this.color,
+      required this.progress})
+      : super(key: key);
+  @override
+  Widget build(BuildContext context) {
+    const count = 3;
+    final margin = size < 30 ? size * 0.01 : size * 0.02;
+    return OsmeaSizedBox(
+      width: size,
+      height: size,
+      child: OsmeaColumn(
+        mainAxisAlignment: centerMain,
+        children: List.generate(count, (i) {
+          return OsmeaRow(
+            mainAxisAlignment: centerMain,
+            children: List.generate(count, (j) {
+              final t = ((progress + (i * count + j) * 0.07) % 1.0);
+              final scale = 0.7 + 0.3 * sin(t * 2 * pi);
+              return Transform.scale(
+                scale: scale,
+                child: OsmeaContainer(
+                  width: size * 0.18,
+                  height: size * 0.18,
+                  margin: EdgeInsets.all(margin),
+                  decoration: BoxDecoration(
+                      color: color, borderRadius: context.borderRadiusLow),
+                ),
+              );
+            }),
+          );
+        }),
+      ),
+    );
+  }
+}
+
+class _DiamondSpinLoading extends StatelessWidget {
+  final double size;
+  final Color color;
+  final double progress;
+  const _DiamondSpinLoading(
+      {Key? key,
+      required this.size,
+      required this.color,
+      required this.progress})
+      : super(key: key);
+  @override
+  Widget build(BuildContext context) {
+    return OsmeaSizedBox(
+      width: size,
+      height: size,
+      child: Transform.rotate(
+        angle: progress * 2 * pi,
+        child: OsmeaCenter(
+          child: OsmeaContainer(
+            width: size * 0.6,
+            height: size * 0.6,
+            decoration: BoxDecoration(
+              color: color,
+              borderRadius: context.borderRadiusMedium,
+              shape: BoxShape.rectangle,
+            ),
+            transform: Matrix4.rotationZ(pi / 4),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _WaveCircleLoading extends StatelessWidget {
+  final double size;
+  final Color color;
+  final double progress;
+  const _WaveCircleLoading(
+      {Key? key,
+      required this.size,
+      required this.color,
+      required this.progress})
+      : super(key: key);
+  @override
+  Widget build(BuildContext context) {
+    const count = 8;
+    return OsmeaSizedBox(
+      width: size,
+      height: size,
+      child: Stack(
+        alignment: center,
+        children: List.generate(count, (i) {
+          final t = ((progress + i / count) % 1.0);
+          final r = size * 0.25 + size * 0.18 * sin(t * 2 * pi);
+          final angle = 2 * pi * i / count;
+          return Transform.translate(
+            offset: Offset(r * cos(angle), r * sin(angle)),
+            child: OsmeaContainer(
+              width: size * 0.13,
+              height: size * 0.13,
+              decoration: BoxDecoration(color: color, shape: BoxShape.circle),
+            ),
+          );
+        }),
+      ),
+    );
+  }
+}
+
+class _FlipSquareLoading extends StatelessWidget {
+  final double size;
+  final Color color;
+  final double progress;
+  const _FlipSquareLoading(
+      {Key? key,
+      required this.size,
+      required this.color,
+      required this.progress})
+      : super(key: key);
+  @override
+  Widget build(BuildContext context) {
+    final t = (progress % 1.0);
+    final angle = pi * t;
+    return OsmeaSizedBox(
+      width: size,
+      height: size,
+      child: OsmeaCenter(
+        child: Transform(
+          alignment: center,
+          transform: Matrix4.rotationY(angle),
+          child: OsmeaContainer(
+            width: size * 0.5,
+            height: size * 0.5,
+            decoration: BoxDecoration(
+              color: color,
+              borderRadius: context.borderRadiusMinStandard,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _ColorFadeLoading extends StatelessWidget {
+  final double size;
+  final Color color;
+  final double progress;
+  const _ColorFadeLoading(
+      {Key? key,
+      required this.size,
+      required this.color,
+      required this.progress})
+      : super(key: key);
+  @override
+  Widget build(BuildContext context) {
+    final t = (progress % 1.0);
+    final c = Color.lerp(color.withAlpha((0.2 * 255).round()), color, t)!;
+    return OsmeaSizedBox(
+      width: size,
+      height: size,
+      child: OsmeaCenter(
+        child: OsmeaContainer(
+          width: size * 0.6,
+          height: size * 0.6,
+          decoration: BoxDecoration(
+            color: c,
+            borderRadius: context.borderRadiusMaxStandard,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _ArcLoaderLoading extends StatelessWidget {
+  final double size;
+  final Color color;
+  final double progress;
+  const _ArcLoaderLoading(
+      {Key? key,
+      required this.size,
+      required this.color,
+      required this.progress})
+      : super(key: key);
+  @override
+  Widget build(BuildContext context) {
+    return OsmeaSizedBox(
+      width: size,
+      height: size,
+      child: CustomPaint(
+        size: Size(size, size),
+        painter: _ArcLoaderPainter(color, progress),
+      ),
+    );
+  }
+}
+
+class _ArcLoaderPainter extends CustomPainter {
+  final Color color;
+  final double progress;
+  _ArcLoaderPainter(this.color, this.progress);
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint()
+      ..color = color
+      ..strokeWidth = size.width * 0.13
+      ..style = PaintingStyle.stroke
+      ..strokeCap = StrokeCap.round;
+    final start = progress * 2 * pi;
+    canvas.drawArc(
+      Rect.fromLTWH(0, 0, size.width, size.height),
+      start,
+      pi * 1.5,
+      false,
+      paint,
+    );
+  }
+
+  @override
+  bool shouldRepaint(covariant CustomPainter oldDelegate) => true;
+}
+
+class _DotFlashLoading extends StatelessWidget {
+  final double size;
+  final Color color;
+  final double progress;
+  const _DotFlashLoading(
+      {Key? key,
+      required this.size,
+      required this.color,
+      required this.progress})
+      : super(key: key);
+  @override
+  Widget build(BuildContext context) {
+    const count = 4;
+    final dotWidth = size / (count * 1.4);
+    final margin = size / (count * 7);
+    return OsmeaSizedBox(
+      width: size,
+      height: size * 0.5,
+      child: OsmeaRow(
+        mainAxisAlignment: centerMain,
+        children: List.generate(count, (i) {
+          final t = ((progress + i * 0.2) % 1.0);
+          final opacity = 0.3 + 0.7 * t;
+          return Opacity(
+            opacity: opacity,
+            child: OsmeaContainer(
+              width: dotWidth,
+              height: dotWidth,
+              margin: EdgeInsets.symmetric(horizontal: margin),
+              decoration: BoxDecoration(color: color, shape: BoxShape.circle),
+            ),
+          );
+        }),
+      ),
+    );
+  }
+}
+
+class _BarWaveLoading extends StatelessWidget {
+  final double size;
+  final Color color;
+  final double progress;
+  const _BarWaveLoading(
+      {Key? key,
+      required this.size,
+      required this.color,
+      required this.progress})
+      : super(key: key);
+  @override
+  Widget build(BuildContext context) {
+    const barCount = 5;
+    final barWidth = size / (barCount * 2.2);
+    final margin = size / (barCount * 7);
+    return OsmeaSizedBox(
+      width: size,
+      height: size * 0.4,
+      child: OsmeaRow(
+        mainAxisAlignment: centerMain,
+        children: List.generate(barCount, (i) {
+          final t = ((progress + i * 0.13) % 1.0);
+          final h = size * 0.18 + size * 0.18 * sin(t * 2 * pi);
+          return OsmeaContainer(
+            width: barWidth,
+            height: h,
+            margin: EdgeInsets.symmetric(horizontal: margin),
+            decoration: BoxDecoration(
+                color: color, borderRadius: context.borderRadiusMinStandard),
+          );
+        }),
+      ),
+    );
+  }
+}
+
+class _AtomLoading extends StatelessWidget {
+  final double size;
+  final Color color;
+  final double progress;
+  const _AtomLoading(
+      {Key? key,
+      required this.size,
+      required this.color,
+      required this.progress})
+      : super(key: key);
+  @override
+  Widget build(BuildContext context) {
+    return OsmeaSizedBox(
+      width: size,
+      height: size,
+      child: Stack(
+        alignment: center,
+        children: [
+          // Merkez nokta
+          OsmeaContainer(
+            width: size * 0.15,
+            height: size * 0.15,
+            decoration: BoxDecoration(color: color, shape: BoxShape.circle),
+          ),
+          Transform.rotate(
+            angle: progress * 2 * pi,
+            child: OsmeaContainer(
+              width: size * 0.6,
+              height: size * 0.6,
+              decoration: BoxDecoration(
+                border: Border.all(
+                    color: color.withAlpha((0.3 * 255).round()),
+                    width: size * 0.02),
+                shape: BoxShape.circle,
+              ),
+            ),
+          ),
+          Transform.rotate(
+            angle: -progress * 2 * pi * 0.7,
+            child: OsmeaContainer(
+              width: size * 0.8,
+              height: size * 0.8,
+              decoration: BoxDecoration(
+                border: Border.all(
+                    color: color.withAlpha((0.2 * 255).round()),
+                    width: size * 0.015),
+                shape: BoxShape.circle,
+              ),
+            ),
+          ),
+          Transform.rotate(
+            angle: progress * 2 * pi,
+            child: OsmeaAlign(
+              alignment: topCenter,
+              child: OsmeaContainer(
+                width: size * 0.08,
+                height: size * 0.08,
+                decoration: BoxDecoration(color: color, shape: BoxShape.circle),
+              ),
+            ),
+          ),
+          Transform.rotate(
+            angle: progress * 2 * pi + pi,
+            child: OsmeaAlign(
+              alignment: bottomCenter,
+              child: OsmeaContainer(
+                width: size * 0.08,
+                height: size * 0.08,
+                decoration: BoxDecoration(color: color, shape: BoxShape.circle),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/packages/components/lib/src/enums/enums.dart
+++ b/packages/components/lib/src/enums/enums.dart
@@ -47,6 +47,9 @@ export 'carousel_enums.dart';
 // List item enums
 export 'list_item_enums.dart';
 
+// Loading enums
+export 'loading_enums.dart';
+
 // ➕ Add other enum files here as they are created
 // export 'input_enums.dart';
 // export 'layout_enums.dart';

--- a/packages/components/lib/src/enums/loading_enums.dart
+++ b/packages/components/lib/src/enums/loading_enums.dart
@@ -1,0 +1,99 @@
+/// 🔄 OSMEA Loading Enums
+///
+/// Copyright (c) 2025, OSMEA Team
+/// https://github.com/masterfabric-mobile/osmea/tree/dev/packages/components
+///
+/// Comprehensive enum definitions for loading components.
+///
+/// {@category Enums}
+/// {@subCategory Loading}
+///
+/// Enums:
+/// * 🔲 LoadingSize - Size variants for loading indicators
+/// * 🔄 LoadingType - Animation types for loading indicators
+///
+/// Example usage:
+/// ```dart
+/// OsmeaComponents.loading(type: LoadingType.rotatingDots, size: 36);
+/// ```
+
+// ignore_for_file: constant_identifier_names
+
+enum LoadingSize {
+  /// 🔹 Extra Small - Minimal loading indicator (16px)
+  extraSmall,
+
+  /// 🔸 Small - Compact loading indicator (24px)
+  small,
+
+  /// 🔶 Medium - Standard loading indicator (32px)
+  medium,
+
+  /// 🔷 Large - Prominent loading indicator (48px)
+  large,
+
+  /// 🔵 Extra Large - Hero loading indicator (64px)
+  extraLarge,
+}
+
+enum LoadingType {
+  /// 🔄 Circular fade animation (classic spinner)
+  circularFade,
+
+  /// ●●● Bouncing dots animation (three dots bouncing)
+  bouncingDots,
+
+  /// ▓▓▓ Wave bars animation (bars moving in wave)
+  waveBars,
+
+  /// ◐ Chasing dots animation (dots chasing in a circle)
+  chasingDots,
+
+  /// ◑ Dual ring animation (two rings spinning)
+  dualRing,
+
+  /// ● Zigzag dots animation (dots moving in zigzag)
+  zigzagDots,
+
+  /// ●●● Triple bounce animation (three balls bouncing)
+  tripleBounce,
+
+  /// ◯ Dot circle animation (dots forming a circle)
+  dotCircle,
+
+  /// ▮▮▮ Bar loader animation (bars growing/shrinking)
+  barLoader,
+
+  /// ◌ Fading circle animation (dots fading in/out in a circle)
+  fadingCircle,
+
+  /// ◉ Rotating dots animation (dots rotating around center)
+  rotatingDots,
+
+  /// ▢ Dancing squares animation (squares moving up/down)
+  dancingSquares,
+
+  /// ⚛️ Atom animation (dots orbiting like an atom)
+  atom,
+
+  /// ⦿ Orbit dot animation (single dot orbiting)
+  orbitDot,
+
+  /// 🌀 Spiral animation (dots moving in spiral)
+  spiral,
+
+  /// ⟳ Rotating arcs animation (arcs spinning)
+  rotatingArcs,
+
+  /// ▦ Grid pulse animation (grid of dots pulsing)
+  gridPulse,
+
+  /// ⭕ Arc loader animation (arc spinning)
+  arcLoader,
+
+  /// ● Dot flash animation (dots flashing in sequence)
+  dotFlash,
+
+  /// ▄ Bar wave animation (bars moving in wave)
+  barWave,
+}

--- a/packages/components/lib/src/utils/loading_extensions.dart
+++ b/packages/components/lib/src/utils/loading_extensions.dart
@@ -1,0 +1,117 @@
+/// 🔄 OSMEA Loading Extensions
+///
+/// Copyright (c) 2025, OSMEA Team
+/// https://github.com/masterfabric-mobile/osmea/tree/dev/packages/components
+///
+/// Extensions for LoadingType, LoadingSize, and LoadingVariant.
+///
+/// {@category Utils}
+/// {@subCategory Loading}
+///
+/// Example usage:
+/// ```dart
+/// LoadingType.rotatingDots.osmeaLoading(size: 36, color: Colors.blue);
+/// ```
+
+import 'package:flutter/material.dart';
+import 'package:osmea_components/src/enums/loading_enums.dart';
+import 'package:flutter/widgets.dart';
+import '../components/loading/loading.dart';
+import '../components/loading/cubit/loading_cubit.dart';
+
+/// Extension for size and stroke width of loading indicators.
+extension LoadingSizeExtension on LoadingSize {
+  /// Returns the pixel size for the loading indicator.
+  double get loadingSize {
+    switch (this) {
+      case LoadingSize.extraSmall:
+        return 16.0;
+      case LoadingSize.small:
+        return 24.0;
+      case LoadingSize.medium:
+        return 32.0;
+      case LoadingSize.large:
+        return 48.0;
+      case LoadingSize.extraLarge:
+        return 64.0;
+    }
+  }
+
+  /// Returns the stroke width for the loading indicator.
+  double get loadingStroke {
+    switch (this) {
+      case LoadingSize.extraSmall:
+        return 2.0;
+      case LoadingSize.small:
+        return 2.5;
+      case LoadingSize.medium:
+        return 3.0;
+      case LoadingSize.large:
+        return 4.0;
+      case LoadingSize.extraLarge:
+        return 5.0;
+    }
+  }
+}
+
+/// Extension for LoadingType utilities and widget builder.
+extension LoadingTypeExtension on LoadingType {
+  /// Builds the loading widget for this type.
+  Widget osmeaLoading({
+    double size = 32,
+    Color? color,
+    LoadingCubit? cubit,
+  }) {
+    final cubit0 = cubit ?? LoadingCubit();
+    cubit0.setType(this);
+    cubit0.setSize(size);
+    if (color != null) cubit0.setColor(color);
+    return CoreLoadingWidget(cubit: cubit0);
+  }
+
+  /// Returns a human-readable label for this loading type.
+  String get label {
+    switch (this) {
+      case LoadingType.circularFade:
+        return 'Circular Fade';
+      case LoadingType.bouncingDots:
+        return 'Bouncing Dots';
+      case LoadingType.waveBars:
+        return 'Wave Bars';
+      case LoadingType.chasingDots:
+        return 'Chasing Dots';
+      case LoadingType.dualRing:
+        return 'Dual Ring';
+      case LoadingType.zigzagDots:
+        return 'Zigzag Dots';
+      case LoadingType.tripleBounce:
+        return 'Triple Bounce';
+      case LoadingType.dotCircle:
+        return 'Dot Circle';
+      case LoadingType.barLoader:
+        return 'Bar Loader';
+      case LoadingType.fadingCircle:
+        return 'Fading Circle';
+      case LoadingType.rotatingDots:
+        return 'Rotating Dots';
+      case LoadingType.dancingSquares:
+        return 'Dancing Squares';
+      case LoadingType.atom:
+        return 'Atom';
+      case LoadingType.orbitDot:
+        return 'Orbit Dot';
+      case LoadingType.spiral:
+        return 'Spiral';
+      case LoadingType.rotatingArcs:
+        return 'Rotating Arcs';
+      case LoadingType.gridPulse:
+        return 'Grid Pulse';
+      case LoadingType.arcLoader:
+        return 'Arc Loader';
+      case LoadingType.dotFlash:
+        return 'Dot Flash';
+      case LoadingType.barWave:
+        return 'Bar Wave';
+    }
+  }
+}


### PR DESCRIPTION
## 📋 PR Description

This PR introduces a **fully extensible and scalable enum-based configuration** structure for the **OSMEA Loading** components. It aims to provide consistent, expressive, and reusable loading animations across the design system with proper sizing, theming, and customization support.

### 🔁 What’s Included?

| Enum          | Purpose                                                           |
| ------------- | ----------------------------------------------------------------- |
| `LoadingSize` | Defines pixel-perfect sizes from `extraSmall` to `extraLarge`     |
| `LoadingType` | Determines visual animation type (e.g., `bouncingDots`, `spiral`) |


### 🎨 Enum Definitions

#### `enum LoadingSize`

* `extraSmall` → 16px
* `small` → 24px
* `medium` → 32px (default)
* `large` → 48px
* `extraLarge` → 64px

#### `enum LoadingType`

Over 20 animation types, including:

* `circularFade`, `bouncingDots`, `waveBars`, `chasingDots`
* `dualRing`, `zigzagDots`, `dotCircle`, `barLoader`, `atom`
* `rotatingDots`, `dancingSquares`, `orbitDot`, `spiral`, `rotatingArcs`
* And many more for modern UI feedback patterns ⚙️

### 📐 Design Principles

| Principle         | Description                                                           |
| ----------------- | --------------------------------------------------------------------- |
| ♻️ Reusability    | Enum-based architecture allows easy addition and maintenance          |
| 🧱 Scalability    | Unified structure supports dozens of animation types and device sizes |
| 🎯 Consistency    | Uniform theme integration across all components                       |
| 🧠 Predictability | Components behave the same way across                                 |

---

## ✅ Checklist

- [ ] Code follows the project standards and guidelines.
- [ ] Relevant unit tests are written and all tests are passing.
- [ ] Test coverage is adequate for the changes.
- [ ] Any unnecessary files or debug statements have been removed.
- [ ] Documentation is updated where necessary.
- [ ] The PR has been reviewed by at least one team member before merging.

---

## 🛠 Steps to Test

1. Navigate to any component or screen where loading indicators are required.
2. Use the `OsmeaComponents.loading()` method with various combinations of:
   - `LoadingType` (e.g. `rotatingDots`, `waveBars`, `tripleBounce`)
   - `LoadingSize` (e.g. `extraSmall`, `medium`, `extraLarge`)
3. Validate that:
   - The selected animation type renders correctly.
   - The sizing corresponds accurately to the enum selection.
   - Loading indicators are centered, smooth, and responsive.
4. Test within different container contexts:
   - Inline inside rows/columns
   - Full-screen overlays
   - Inside modals or cards
5. Confirm visual consistency across platforms and themes (light/dark).

---

### 📷 Screenshots (Optional)
<table>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/403af981-a8a8-4e45-9871-19bfa49ca414" width="140"/></td>
    <td><img src="https://github.com/user-attachments/assets/b1b426e9-3cbc-49d6-a58e-13fe75482dc3" width="140"/></td>
    <td><img src="https://github.com/user-attachments/assets/6efc9fb9-62eb-4d57-87bb-cf25c94a950e" width="140"/></td>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/b7c49855-59a4-4a86-8f7a-b5e06e2e9508" width="140"/></td>
    <td><img src="https://github.com/user-attachments/assets/f8c76a9e-3bcf-4599-8406-1ba77960ae34" width="140"/></td>
    <td><img src="https://github.com/user-attachments/assets/3b9739a4-424c-44a9-8783-dd38c4ac6452" width="140"/></td>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/061969ba-6a91-4024-9865-edbf55956b3c" width="140"/></td>
    <td><img src="https://github.com/user-attachments/assets/7f4a90e6-530b-4645-b9bf-7f8584964b59" width="140"/></td>
    <td><img src="https://github.com/user-attachments/assets/ed9c159a-4507-4290-b902-d0181478da8b" width="140"/></td>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/a9a410c5-1ae6-429b-9c17-9553ea28ee7b" width="140"/></td>
    <td><img src="https://github.com/user-attachments/assets/55a8378e-5005-498c-a30b-6b997bc25932" width="140"/></td>
    <td></td>
  </tr>
</table>
