### PR TITLE
OSMEA - Components - Storybook -> Badge

### DIFF
--- a/packages/components/example_storybook/lib/storybook_test/component_registry.dart
+++ b/packages/components/example_storybook/lib/storybook_test/component_registry.dart
@@ -36,6 +36,13 @@ class ComponentRegistry {
       storyPath: StoryConfig.buildComponentStoryName('Buttons'),
     ),
     ComponentInfo(
+      name: 'Badges',
+      description: 'Notification indicators and status markers',
+      icon: Icons.label,
+      color: Colors.amber,
+      storyPath: StoryConfig.buildComponentStoryName('Badges'),
+    ),
+    ComponentInfo(
       name: 'Text Fields',
       description: 'Input fields for forms and data entry',
       icon: Icons.text_fields,

--- a/packages/components/example_storybook/lib/storybook_test/components/badge_test_modular/badges.dart
+++ b/packages/components/example_storybook/lib/storybook_test/components/badge_test_modular/badges.dart
@@ -1,0 +1,20 @@
+import 'package:storybook_flutter/storybook_flutter.dart';
+
+// Import the unified badge showcase
+import 'showcase/unified_badge_showcase.dart';
+
+/// 🏷️ **Badge Component Stories - Modular Structure**
+/// 
+/// Main aggregation function for all badge stories following the modular template.
+/// This file serves as the entry point for all badge-related showcases.
+
+List<Story> getAllBadgeStories() {
+  return [
+    // Unified Badge Showcase - Moon Design Style
+    ...getUnifiedBadgeShowcase(),
+    
+    // Note: Individual badge stories are replaced by unified showcase
+    // This new approach shows all badge variations in one place
+    // with all knobs affecting every badge simultaneously
+  ];
+}

--- a/packages/components/example_storybook/lib/storybook_test/components/badge_test_modular/data/badge_data.dart
+++ b/packages/components/example_storybook/lib/storybook_test/components/badge_test_modular/data/badge_data.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/material.dart';
+
+/// 🏷️ **Badge Data**
+/// 
+/// Sample data and constants for badge examples
+
+class BadgeData {
+  /// Sample badge contents for demonstrations
+  static const List<String> sampleTexts = [
+    'New',
+    'Hot',
+    'Sale',
+    'Pro',
+    'Beta',
+    'VIP',
+    'Live',
+    'Free',
+  ];
+
+  /// Sample counts for numeric badges
+  static const List<int> sampleCounts = [
+    1, 3, 5, 8, 12, 25, 42, 99, 150, 999, 1250,
+  ];
+
+  /// Sample icons for demonstration
+  static const List<IconData> sampleIcons = [
+    Icons.notifications,
+    Icons.mail,
+    Icons.message,
+    Icons.shopping_cart,
+    Icons.favorite,
+    Icons.chat,
+    Icons.settings,
+    Icons.help,
+  ];
+
+  /// Color combinations for custom badges
+  static final List<Map<String, Color>> colorCombinations = [
+    {
+      'background': Colors.purple.shade100,
+      'text': Colors.purple.shade800,
+      'border': Colors.purple.shade300,
+    },
+    {
+      'background': Colors.pink.shade100,
+      'text': Colors.pink.shade800,
+      'border': Colors.pink.shade300,
+    },
+    {
+      'background': Colors.indigo.shade100,
+      'text': Colors.indigo.shade800,
+      'border': Colors.indigo.shade300,
+    },
+    {
+      'background': Colors.teal.shade100,
+      'text': Colors.teal.shade800,
+      'border': Colors.teal.shade300,
+    },
+  ];
+
+  /// Demonstration scenarios with descriptions
+  static const List<Map<String, String>> scenarios = [
+    {
+      'title': 'Notification Count',
+      'description': 'Show unread message count',
+      'example': 'Messages app badge showing "8" new messages',
+    },
+    {
+      'title': 'Status Indicator',
+      'description': 'Display current status',
+      'example': 'Online/offline status with colored dot',
+    },
+    {
+      'title': 'Feature Label',
+      'description': 'Highlight new features',
+      'example': 'New feature tagged with "New" badge',
+    },
+    {
+      'title': 'Promotional Tag',
+      'description': 'Mark special offers',
+      'example': 'Sale items marked with "Sale" badge',
+    },
+  ];
+}

--- a/packages/components/example_storybook/lib/storybook_test/components/badge_test_modular/sections/header_section.dart
+++ b/packages/components/example_storybook/lib/storybook_test/components/badge_test_modular/sections/header_section.dart
@@ -1,0 +1,97 @@
+import 'package:flutter/material.dart';
+import 'package:osmea_components/osmea_components.dart';
+
+/// 📋 **Badge Header Section**
+/// 
+/// Header component for the badge showcase with title, subtitle, and info chips
+
+class BadgeHeaderSection extends StatelessWidget {
+  final String title;
+  final String subtitle;
+  final bool isDark;
+  final Map<String, String> infoChips;
+
+  const BadgeHeaderSection({
+    Key? key,
+    required this.title,
+    required this.subtitle,
+    this.isDark = false,
+    this.infoChips = const {},
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final titleColor = isDark ? Colors.white : OsmeaColors.nordicBlue;
+    final subtitleColor = isDark ? Colors.grey.shade300 : OsmeaColors.pewter;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        // Main Title
+        Text(
+          title,
+          style: TextStyle(
+            fontSize: 28,
+            fontWeight: FontWeight.bold,
+            color: titleColor,
+          ),
+        ),
+        const SizedBox(height: 8),
+        
+        // Subtitle
+        Text(
+          subtitle,
+          style: TextStyle(
+            fontSize: 16,
+            color: subtitleColor,
+            height: 1.4,
+          ),
+        ),
+        
+        if (infoChips.isNotEmpty) ...[
+          const SizedBox(height: 16),
+          
+          // Info Chips
+          Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            children: infoChips.entries.map((entry) {
+              return Container(
+                padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+                decoration: BoxDecoration(
+                  color: isDark ? Colors.grey.shade700 : OsmeaColors.silver.withOpacity(0.3),
+                  borderRadius: BorderRadius.circular(16),
+                  border: Border.all(
+                    color: isDark ? Colors.grey.shade600 : OsmeaColors.silver,
+                    width: 1,
+                  ),
+                ),
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Text(
+                      entry.key,
+                      style: TextStyle(
+                        fontSize: 12,
+                        fontWeight: FontWeight.w600,
+                        color: isDark ? Colors.grey.shade300 : OsmeaColors.pewter,
+                      ),
+                    ),
+                    const SizedBox(width: 4),
+                    Text(
+                      entry.value,
+                      style: TextStyle(
+                        fontSize: 12,
+                        color: isDark ? Colors.white : OsmeaColors.nordicBlue,
+                      ),
+                    ),
+                  ],
+                ),
+              );
+            }).toList(),
+          ),
+        ],
+      ],
+    );
+  }
+}

--- a/packages/components/example_storybook/lib/storybook_test/components/badge_test_modular/sections/sample_content_section.dart
+++ b/packages/components/example_storybook/lib/storybook_test/components/badge_test_modular/sections/sample_content_section.dart
@@ -1,0 +1,356 @@
+import 'package:flutter/material.dart';
+import 'package:osmea_components/osmea_components.dart';
+import '../utils/badge_builder.dart';
+
+/// 📝 **Sample Content Section**
+/// 
+/// Demonstrates badge usage with sample content and real-world scenarios
+
+class SampleContentSection extends StatelessWidget {
+  final BadgeVariant variant;
+  final BadgeSize size;
+  final BadgeShape shape;
+  final BadgeStyle style;
+  final BadgeState state;
+  final String text;
+  final int? count;
+  final IconData selectedIcon;
+  final Color? backgroundColor;
+  final Color? foregroundColor;
+  final BadgePosition position;
+  final double horizontalOffset;
+  final double verticalOffset;
+  final bool enableInteraction;
+  final bool isDark;
+  final double spacing;
+
+  const SampleContentSection({
+    Key? key,
+    required this.variant,
+    required this.size,
+    required this.shape,
+    required this.style,
+    required this.state,
+    required this.text,
+    this.count,
+    required this.selectedIcon,
+    this.backgroundColor,
+    this.foregroundColor,
+    required this.position,
+    this.horizontalOffset = 0.0,
+    this.verticalOffset = 0.0,
+    this.enableInteraction = true,
+    this.isDark = false,
+    this.spacing = 16.0,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        // Notification Context Example
+        _buildNotificationExample(context),
+        SizedBox(height: spacing * 2),
+        
+        // E-commerce Context Example
+        _buildEcommerceExample(context),
+        SizedBox(height: spacing * 2),
+        
+        // Social Media Context Example
+        _buildSocialExample(context),
+        SizedBox(height: spacing * 2),
+        
+        // Dashboard Context Example
+        _buildDashboardExample(context),
+      ],
+    );
+  }
+
+  Widget _buildNotificationExample(BuildContext context) {
+    return _buildSampleCard(
+      context,
+      title: "Notifications",
+      description: "Badges for message counts and alerts",
+      child: Row(
+        children: [
+          // Message Icon with Badge
+          _buildWithBadge(
+            context,
+            child: Icon(
+              Icons.message,
+              size: 32,
+              color: isDark ? Colors.white : OsmeaColors.nordicBlue,
+            ),
+            badgeText: "3",
+            badgeCount: 3,
+          ),
+          SizedBox(width: spacing),
+          
+          // Bell Icon with Badge
+          _buildWithBadge(
+            context,
+            child: Icon(
+              Icons.notifications,
+              size: 32,
+              color: isDark ? Colors.white : OsmeaColors.nordicBlue,
+            ),
+            badgeText: "New",
+            badgeCount: null,
+          ),
+          SizedBox(width: spacing),
+          
+          // Mail Icon with Badge
+          _buildWithBadge(
+            context,
+            child: Icon(
+              Icons.email,
+              size: 32,
+              color: isDark ? Colors.white : OsmeaColors.nordicBlue,
+            ),
+            badgeText: "99+",
+            badgeCount: 99,
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildEcommerceExample(BuildContext context) {
+    return _buildSampleCard(
+      context,
+      title: "E-commerce",
+      description: "Product tags and sale indicators",
+      child: Row(
+        children: [
+          // Product with Sale Badge
+          _buildWithBadge(
+            context,
+            child: Container(
+              width: 60,
+              height: 60,
+              decoration: BoxDecoration(
+                color: OsmeaColors.silver.withOpacity(0.3),
+                borderRadius: BorderRadius.circular(8),
+              ),
+              child: Icon(
+                Icons.shopping_bag,
+                color: isDark ? Colors.white : OsmeaColors.nordicBlue,
+              ),
+            ),
+            badgeText: "SALE",
+            badgeCount: null,
+            badgeColor: Colors.red,
+          ),
+          SizedBox(width: spacing),
+          
+          // Cart with Item Count
+          _buildWithBadge(
+            context,
+            child: Icon(
+              Icons.shopping_cart,
+              size: 32,
+              color: isDark ? Colors.white : OsmeaColors.nordicBlue,
+            ),
+            badgeText: "5",
+            badgeCount: 5,
+          ),
+          SizedBox(width: spacing),
+          
+          // Wishlist with Badge
+          _buildWithBadge(
+            context,
+            child: Icon(
+              Icons.favorite,
+              size: 32,
+              color: isDark ? Colors.white : OsmeaColors.nordicBlue,
+            ),
+            badgeText: "Hot",
+            badgeCount: null,
+            badgeColor: OsmeaColors.sunsetGlow,
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSocialExample(BuildContext context) {
+    return _buildSampleCard(
+      context,
+      title: "Social Media",
+      description: "Status indicators and engagement metrics",
+      child: Row(
+        children: [
+          // User Avatar with Online Status
+          _buildWithBadge(
+            context,
+            child: CircleAvatar(
+              radius: 20,
+              backgroundColor: OsmeaColors.silver,
+              child: Icon(
+                Icons.person,
+                color: isDark ? Colors.white : OsmeaColors.nordicBlue,
+              ),
+            ),
+            badgeText: "",
+            badgeCount: null,
+            badgeColor: OsmeaColors.forestHeart,
+            badgeSize: BadgeSize.small,
+          ),
+          SizedBox(width: spacing),
+          
+          // Likes with Count
+          _buildWithBadge(
+            context,
+            child: Icon(
+              Icons.thumb_up,
+              size: 32,
+              color: isDark ? Colors.white : OsmeaColors.nordicBlue,
+            ),
+            badgeText: "42",
+            badgeCount: 42,
+          ),
+          SizedBox(width: spacing),
+          
+          // Comments with Badge
+          _buildWithBadge(
+            context,
+            child: Icon(
+              Icons.comment,
+              size: 32,
+              color: isDark ? Colors.white : OsmeaColors.nordicBlue,
+            ),
+            badgeText: "8",
+            badgeCount: 8,
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildDashboardExample(BuildContext context) {
+    return _buildSampleCard(
+      context,
+      title: "Dashboard",
+      description: "Status indicators and metrics",
+      child: Row(
+        children: [
+          // Server Status
+          _buildWithBadge(
+            context,
+            child: Icon(
+              Icons.computer,
+              size: 32,
+              color: isDark ? Colors.white : OsmeaColors.nordicBlue,
+            ),
+            badgeText: "OK",
+            badgeCount: null,
+            badgeColor: OsmeaColors.forestHeart,
+          ),
+          SizedBox(width: spacing),
+          
+          // Alerts Count
+          _buildWithBadge(
+            context,
+            child: Icon(
+              Icons.warning,
+              size: 32,
+              color: isDark ? Colors.white : OsmeaColors.nordicBlue,
+            ),
+            badgeText: "2",
+            badgeCount: 2,
+            badgeColor: OsmeaColors.sunsetGlow,
+          ),
+          SizedBox(width: spacing),
+          
+          // Tasks Progress
+          _buildWithBadge(
+            context,
+            child: Icon(
+              Icons.task,
+              size: 32,
+              color: isDark ? Colors.white : OsmeaColors.nordicBlue,
+            ),
+            badgeText: "75%",
+            badgeCount: null,
+            badgeColor: OsmeaColors.nordicBlue,
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSampleCard(
+    BuildContext context, {
+    required String title,
+    required String description,
+    required Widget child,
+  }) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: isDark ? Colors.grey.shade800 : Colors.white,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(
+          color: isDark ? Colors.grey.shade700 : OsmeaColors.silver,
+          width: 1,
+        ),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            title,
+            style: TextStyle(
+              fontSize: 18,
+              fontWeight: FontWeight.bold,
+              color: isDark ? Colors.white : OsmeaColors.nordicBlue,
+            ),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            description,
+            style: TextStyle(
+              fontSize: 14,
+              color: isDark ? Colors.grey.shade300 : OsmeaColors.pewter,
+            ),
+          ),
+          const SizedBox(height: 16),
+          child,
+        ],
+      ),
+    );
+  }
+
+  Widget _buildWithBadge(
+    BuildContext context, {
+    required Widget child,
+    required String badgeText,
+    required int? badgeCount,
+    Color? badgeColor,
+    BadgeSize? badgeSize,
+  }) {
+    // Determine content based on what's provided
+    dynamic content;
+    if (badgeCount != null) {
+      content = badgeCount;
+    } else if (badgeText.isNotEmpty) {
+      content = badgeText;
+    } else {
+      content = null; // Dot badge
+    }
+
+    return BadgeBuilder.buildBadge(
+      variant: variant,
+      size: badgeSize ?? size,
+      shape: shape,
+      style: style,
+      state: state,
+      position: position,
+      content: content,
+      backgroundColor: badgeColor ?? backgroundColor,
+      textColor: foregroundColor,
+      child: child,
+    );
+  }
+}

--- a/packages/components/example_storybook/lib/storybook_test/components/badge_test_modular/showcase/badge_showcase_widget.dart
+++ b/packages/components/example_storybook/lib/storybook_test/components/badge_test_modular/showcase/badge_showcase_widget.dart
@@ -71,7 +71,7 @@ class UnifiedBadgeShowcaseWidget extends StatelessWidget {
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
               // Title
-              Text(
+              const Text (
                 '🏷️ Badge Features Showcase',
                 style: TextStyle(
                   fontSize: 24,
@@ -320,80 +320,6 @@ class UnifiedBadgeShowcaseWidget extends StatelessWidget {
         ],
       ),
     );
-  }
-
-  // Build parent widget based on selected type (matches badge_example.dart scenarios)
-  Widget _buildParentChild() {
-    switch (parentType) {
-      case 'Avatar':
-        return const CircleAvatar(
-          radius: 24,
-          backgroundColor: Colors.blue,
-          child: Icon(Icons.person, color: Colors.white, size: 20),
-        );
-      case 'Button':
-        return ElevatedButton(
-          onPressed: () {},
-          style: ElevatedButton.styleFrom(
-            backgroundColor: Colors.blue,
-            foregroundColor: Colors.white,
-            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-            shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
-          ),
-          child: const Text('Messages'),
-        );
-      case 'Tag':
-        return Container(
-          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-          decoration: BoxDecoration(
-            color: Colors.grey.shade100,
-            borderRadius: BorderRadius.circular(6),
-          ),
-          child: const Text('Product', style: TextStyle(fontSize: 14, color: Colors.black87)),
-        );
-      case 'Card':
-        return Container(
-          width: 60,
-          height: 40,
-          decoration: BoxDecoration(
-            color: Colors.white,
-            borderRadius: BorderRadius.circular(8),
-            border: Border.all(color: Colors.grey.shade300),
-          ),
-          child: const Center(
-            child: Icon(Icons.credit_card, size: 20, color: Colors.black54),
-          ),
-        );
-      case 'Menu':
-        return Container(
-          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-          decoration: BoxDecoration(
-            color: Colors.blue.shade50,
-            borderRadius: BorderRadius.circular(8),
-          ),
-          child: const Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Icon(Icons.menu, size: 18, color: Colors.blue),
-              SizedBox(width: 8),
-              Text('Menu', style: TextStyle(fontSize: 14, color: Colors.blue, fontWeight: FontWeight.w500)),
-            ],
-          ),
-        );
-      case 'None':
-        return const SizedBox.shrink();
-      case 'Icon':
-      default:
-        return Container(
-          width: 50,
-          height: 50,
-          decoration: BoxDecoration(
-            color: Colors.grey.shade200,
-            borderRadius: BorderRadius.circular(8),
-          ),
-          child: const Icon(Icons.notifications, size: 24, color: Colors.black54),
-        );
-    }
   }
 
   // Clamp position to the four corners; default to topRight if unsupported

--- a/packages/components/example_storybook/lib/storybook_test/components/badge_test_modular/showcase/badge_showcase_widget.dart
+++ b/packages/components/example_storybook/lib/storybook_test/components/badge_test_modular/showcase/badge_showcase_widget.dart
@@ -1,0 +1,404 @@
+import 'package:flutter/material.dart';
+import 'package:osmea_components/osmea_components.dart';
+import '../utils/badge_builder.dart';
+
+/// 🏷️ **Badge Showcase Widget**
+/// 
+/// Simple, clean showcase that displays a single badge that responds to all knob changes
+class UnifiedBadgeShowcaseWidget extends StatelessWidget {
+  // Badge Properties
+  final BadgeSize size;
+  final BadgeVariant variant;
+  final BadgeStyle style;
+  final BadgeState state;
+  final BadgeShape shape;
+  final BadgePosition position;
+  final IconData iconData;
+  
+  // Content
+  final String contentType;
+  final String textContent;
+  final int numberContent;
+  
+  // Parent Widget
+  final String parentType;
+  
+  // Custom Colors
+  final Color? customBackgroundColor;
+  final Color? customTextColor;
+  final Color? customBorderColor;
+  
+  // Interactive Features
+  final bool enableInteraction;
+  final int? maxCount;
+  final bool showZero;
+  
+  // Layout Options
+  final double spacing;
+
+  const UnifiedBadgeShowcaseWidget({
+    super.key,
+    required this.size,
+    required this.variant,
+    required this.style,
+    required this.state,
+    required this.shape,
+    required this.position,
+    required this.contentType,
+    required this.textContent,
+    required this.numberContent,
+    required this.parentType,
+    this.customBackgroundColor,
+    this.customTextColor,
+    this.customBorderColor,
+    required this.enableInteraction,
+    this.maxCount,
+    required this.showZero,
+    required this.spacing,
+    required this.iconData,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      height: double.infinity,
+      color: Colors.white,
+      child: Center(
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.all(20),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              // Title
+              Text(
+                '🏷️ Badge Features Showcase',
+                style: TextStyle(
+                  fontSize: 24,
+                  fontWeight: FontWeight.bold,
+                  color: Colors.black87,
+                ),
+              ),
+              const SizedBox(height: 32),
+              
+              // Main demonstration - 6 carefully chosen badges that show ALL features
+              Wrap(
+                spacing: 40,
+                runSpacing: 40,
+                alignment: WrapAlignment.center,
+                children: [
+                  // 1. Standard Badge (variants / size / shape / state)
+                  _buildFeatureBadge(
+                    title: 'Standard Badge',
+                    description: 'Variant • Size • Shape • State',
+                    badge: _createStandardBadge(),
+                  ),
+
+                  // 2. Icon Badge (badge attached to changeable icon)
+                  _buildFeatureBadge(
+                    title: 'Icon Badge',
+                    description: 'Icon • Position • Interactive',
+                    badge: _createIconBadge(),
+                  ),
+
+                  // 3. Dot Badge (dot indicator on icon)
+                  _buildFeatureBadge(
+                    title: 'Dot Badge',
+                    description: 'Dot • Position',
+                    badge: _createDotBadge(),
+                  ),
+                ],
+              ),
+              
+              const SizedBox(height: 40),
+              
+              // Current Configuration Panel
+              _buildConfigurationInfo(context),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  // Feature showcase methods that demonstrate ALL badge capabilities
+  Widget _buildFeatureBadge({
+    required String title,
+    required String description,
+    required Widget badge,
+  }) {
+    return Container(
+      width: 200,
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(12),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withAlpha(25),
+            blurRadius: 10,
+            offset: const Offset(0, 2),
+          ),
+        ],
+        border: Border.all(color: Colors.grey.shade200),
+      ),
+      child: Column(
+        children: [
+          Container(
+            height: 80,
+            alignment: Alignment.center,
+            child: badge,
+          ),
+          const SizedBox(height: 12),
+          Text(
+            title,
+            style: const TextStyle(
+              fontSize: 16,
+              fontWeight: FontWeight.bold,
+              color: Colors.black87,
+            ),
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 4),
+          Text(
+            description,
+            style: const TextStyle(
+              fontSize: 12,
+              color: Colors.black54,
+            ),
+            textAlign: TextAlign.center,
+          ),
+        ],
+      ),
+    );
+  }
+
+  // Generates Standard Badge (standalone)
+  Widget _createStandardBadge() {
+    return Builder(
+      builder: (context) => BadgeBuilder.buildBadge(
+        size: size,
+        variant: variant,
+        style: style,
+        state: state,
+        child: null,
+        shape: shape,
+        padding: null,
+        content: contentType == 'Number' ? numberContent : textContent,
+        backgroundColor: customBackgroundColor,
+        textColor: customTextColor,
+        borderColor: customBorderColor,
+        onTap: enableInteraction ? () {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text('Standard badge tapped!')),
+          );
+        } : null,
+      ),
+    );
+  }
+
+  // Generates Icon Badge attached to selectable icon
+  Widget _createIconBadge() {
+    // Hide badge but keep icon when count is zero and showZero is false
+    if (contentType == 'Number' && numberContent == 0 && !showZero) {
+      return Icon(iconData, size: 40, color: Colors.black54);
+    }
+    return Builder(
+      builder: (context) => BadgeBuilder.buildBadge(
+        size: BadgeSize.extraSmall,
+        variant: variant,
+        style: style,
+        state: state,
+        shape: BadgeShape.circular,
+        position: _clampedPosition(),
+        content: () {
+          if (contentType == 'Number') return numberContent;
+          if (contentType == 'Text') return textContent;
+          // For Icon+Text, keep using numberContent so badge still shows count
+          return numberContent;
+        }(),
+        child: Icon(iconData, size: 40, color: Colors.black54),
+        backgroundColor: customBackgroundColor,
+        textColor: customTextColor,
+        borderColor: customBorderColor,
+        maxCount: maxCount,
+        showZero: showZero,
+        onTap: enableInteraction ? () {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text('Icon badge tapped!')),
+          );
+        } : null,
+      ),
+    );
+  }
+
+  // Generates Dot Badge attached to same icon
+  Widget _createDotBadge() {
+    return Builder(
+      builder: (context) => BadgeBuilder.buildBadge(
+        size: BadgeSize.dot,
+        variant: variant,
+        style: style,
+        state: state,
+        shape: BadgeShape.circular,
+        position: _clampedPosition(),
+        content: null,
+        child: Icon(iconData, size: 40, color: Colors.black54),
+        backgroundColor: customBackgroundColor,
+        onTap: enableInteraction ? () {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text('Dot badge tapped!')),
+          );
+        } : null,
+      ),
+    );
+  }
+
+  Widget _buildConfigurationInfo(BuildContext context) {
+    // Determine content type for display
+    String contentDisplay;
+    if (contentType == 'Text') {
+      contentDisplay = 'Text: "$textContent"';
+    } else {
+      contentDisplay = 'Number: $numberContent';
+    }
+
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: Colors.grey[50],
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: Colors.grey[300]!),
+      ),
+      child: Column(
+        children: [
+          Text(
+            'Current Configuration',
+            style: Theme.of(context).textTheme.titleMedium?.copyWith(
+              fontWeight: FontWeight.bold,
+              color: Colors.black87,
+            ),
+          ),
+          const SizedBox(height: 12),
+          _buildConfigRow('Size', size.toString().split('.').last),
+          _buildConfigRow('Variant', variant.toString().split('.').last),
+          _buildConfigRow('Style', style.toString().split('.').last),
+          _buildConfigRow('State', state.toString().split('.').last),
+          _buildConfigRow('Shape', shape.toString().split('.').last),
+          _buildConfigRow('Position', position.toString().split('.').last),
+          _buildConfigRow('Content', contentDisplay),
+          _buildConfigRow('Badge Visible', (!showZero && contentType == 'Number' && numberContent == 0) ? 'No (Zero Count Hidden)' : 'Yes'),
+          _buildConfigRow('Parent', parentType),
+          _buildConfigRow('Interactive', enableInteraction ? 'Yes' : 'No'),
+          if (maxCount != null)
+            _buildConfigRow('Max Count', maxCount.toString()),
+          _buildConfigRow('Show Zero', showZero ? 'Yes' : 'No'),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildConfigRow(String label, String value) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 2),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Text(
+            label,
+            style: const TextStyle(
+              fontWeight: FontWeight.w500,
+              color: Colors.black87,
+            ),
+          ),
+          Text(
+            value,
+            style: const TextStyle(
+              color: Colors.black54,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  // Build parent widget based on selected type (matches badge_example.dart scenarios)
+  Widget _buildParentChild() {
+    switch (parentType) {
+      case 'Avatar':
+        return const CircleAvatar(
+          radius: 24,
+          backgroundColor: Colors.blue,
+          child: Icon(Icons.person, color: Colors.white, size: 20),
+        );
+      case 'Button':
+        return ElevatedButton(
+          onPressed: () {},
+          style: ElevatedButton.styleFrom(
+            backgroundColor: Colors.blue,
+            foregroundColor: Colors.white,
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+            shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+          ),
+          child: const Text('Messages'),
+        );
+      case 'Tag':
+        return Container(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+          decoration: BoxDecoration(
+            color: Colors.grey.shade100,
+            borderRadius: BorderRadius.circular(6),
+          ),
+          child: const Text('Product', style: TextStyle(fontSize: 14, color: Colors.black87)),
+        );
+      case 'Card':
+        return Container(
+          width: 60,
+          height: 40,
+          decoration: BoxDecoration(
+            color: Colors.white,
+            borderRadius: BorderRadius.circular(8),
+            border: Border.all(color: Colors.grey.shade300),
+          ),
+          child: const Center(
+            child: Icon(Icons.credit_card, size: 20, color: Colors.black54),
+          ),
+        );
+      case 'Menu':
+        return Container(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+          decoration: BoxDecoration(
+            color: Colors.blue.shade50,
+            borderRadius: BorderRadius.circular(8),
+          ),
+          child: const Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(Icons.menu, size: 18, color: Colors.blue),
+              SizedBox(width: 8),
+              Text('Menu', style: TextStyle(fontSize: 14, color: Colors.blue, fontWeight: FontWeight.w500)),
+            ],
+          ),
+        );
+      case 'None':
+        return const SizedBox.shrink();
+      case 'Icon':
+      default:
+        return Container(
+          width: 50,
+          height: 50,
+          decoration: BoxDecoration(
+            color: Colors.grey.shade200,
+            borderRadius: BorderRadius.circular(8),
+          ),
+          child: const Icon(Icons.notifications, size: 24, color: Colors.black54),
+        );
+    }
+  }
+
+  // Clamp position to the four corners; default to topRight if unsupported
+  BadgePosition _clampedPosition() {
+    const allowed = [BadgePosition.topRight, BadgePosition.topLeft, BadgePosition.bottomRight, BadgePosition.bottomLeft];
+    return allowed.contains(position) ? position : BadgePosition.topRight;
+  }
+}

--- a/packages/components/example_storybook/lib/storybook_test/components/badge_test_modular/showcase/unified_badge_showcase.dart
+++ b/packages/components/example_storybook/lib/storybook_test/components/badge_test_modular/showcase/unified_badge_showcase.dart
@@ -1,0 +1,213 @@
+import 'package:flutter/material.dart';
+import 'package:osmea_components/osmea_components.dart';
+import 'package:storybook_flutter/storybook_flutter.dart';
+
+// Import the main showcase widget
+import 'badge_showcase_widget.dart';
+
+/// 🏷️ **Unified Badge Showcase - Modular Structure**
+/// 
+/// Single story that shows all badge variations in one place
+/// All knobs control the badge simultaneously for easy testing
+/// 
+/// This modular version uses the template structure:
+/// - showcase/ for main widget
+/// - utils/ for helper functions
+/// - data/ for sample content
+
+List<Story> getUnifiedBadgeShowcase() {
+  return [
+    Story(
+      name: 'Badges',
+      builder: (context) => UnifiedBadgeShowcaseWidget(
+        // Size Controls
+        size: context.knobs.options(
+          label: 'Size',
+          initial: BadgeSize.medium,
+          options: const [
+            Option(label: 'Extra Small', value: BadgeSize.extraSmall),
+            Option(label: 'Small', value: BadgeSize.small),
+            Option(label: 'Medium', value: BadgeSize.medium),
+            Option(label: 'Large', value: BadgeSize.large),
+            Option(label: 'Extra Large', value: BadgeSize.extraLarge),
+          ],
+        ),
+        
+        // Variant Controls
+        variant: context.knobs.options(
+          label: 'Variant',
+          initial: BadgeVariant.primary,
+          options: const [
+            Option(label: 'Primary', value: BadgeVariant.primary),
+            Option(label: 'Secondary', value: BadgeVariant.secondary),
+            Option(label: 'Success', value: BadgeVariant.success),
+            Option(label: 'Warning', value: BadgeVariant.warning),
+            Option(label: 'Danger', value: BadgeVariant.danger),
+            Option(label: 'Info', value: BadgeVariant.info),
+            Option(label: 'Neutral', value: BadgeVariant.neutral),
+            Option(label: 'Custom', value: BadgeVariant.custom),
+          ],
+        ),
+        
+        // Style Controls
+        style: context.knobs.options(
+          label: 'Style',
+          initial: BadgeStyle.normal,
+          options: const [
+            Option(label: 'Normal', value: BadgeStyle.normal),
+            Option(label: 'Soft', value: BadgeStyle.soft),
+            Option(label: 'Outlined', value: BadgeStyle.outlined),
+            Option(label: 'Ghost', value: BadgeStyle.ghost),
+            Option(label: 'Mixed', value: BadgeStyle.mixed),
+          ],
+        ),
+        
+        // State Controls
+        state: context.knobs.options(
+          label: 'State',
+          initial: BadgeState.enabled,
+          options: const [
+            Option(label: 'Enabled', value: BadgeState.enabled),
+            Option(label: 'Disabled', value: BadgeState.disabled),
+            Option(label: 'Active', value: BadgeState.active),
+            Option(label: 'Clickable', value: BadgeState.clickable),
+          ],
+        ),
+        
+        // Shape Controls
+        shape: context.knobs.options(
+          label: 'Shape',
+          initial: BadgeShape.circular,
+          options: const [
+            Option(label: 'Circular', value: BadgeShape.circular),
+            Option(label: 'Rounded', value: BadgeShape.rounded),
+            Option(label: 'Pill', value: BadgeShape.pill),
+            Option(label: 'Square', value: BadgeShape.square),
+            Option(label: 'Rectangle', value: BadgeShape.rectangle),
+          ],
+        ),
+        
+        // Position Controls (corners only)
+        position: context.knobs.options(
+          label: 'Position',
+          initial: BadgePosition.topRight,
+          options: const [
+            Option(label: 'Top Right', value: BadgePosition.topRight),
+            Option(label: 'Top Left', value: BadgePosition.topLeft),
+            Option(label: 'Bottom Right', value: BadgePosition.bottomRight),
+            Option(label: 'Bottom Left', value: BadgePosition.bottomLeft),
+          ],
+        ),
+        
+        // Content Type Control
+        contentType: context.knobs.options(
+          label: 'Content Type',
+          initial: 'Number',
+          options: const [
+            Option(label: 'Number', value: 'Number'),
+            Option(label: 'Text', value: 'Text'),
+          ],
+        ),
+        
+        // Content Controls
+        textContent: context.knobs.options(
+          label: 'Text Content',
+          initial: 'New',
+          options: const [
+            Option(label: 'New', value: 'New'),
+            Option(label: 'Hot', value: 'Hot'),
+            Option(label: 'Sale', value: 'Sale'),
+            Option(label: 'Pro', value: 'Pro'),
+            Option(label: 'Beta', value: 'Beta'),
+            Option(label: 'VIP', value: 'VIP'),
+            Option(label: 'Live', value: 'Live'),
+            Option(label: 'Free', value: 'Free'),
+            Option(label: 'Popular', value: 'Popular'),
+            Option(label: 'Featured', value: 'Featured'),
+          ],
+        ),
+        
+        numberContent: context.knobs.slider(
+          label: 'Number Content',
+          initial: 8,
+          min: 0,
+          max: 1500,
+        ).round(),
+        
+        // Icon Control
+        iconData: context.knobs.options(
+          label: 'Icon',
+          initial: Icons.notifications,
+          options: const [
+            Option(label: 'Notifications', value: Icons.notifications),
+            Option(label: 'Mail', value: Icons.mail),
+            Option(label: 'Chat', value: Icons.chat),
+            Option(label: 'Shopping Cart', value: Icons.shopping_cart),
+            Option(label: 'Star', value: Icons.star),
+          ],
+        ),
+        
+        // Color Controls
+        customBackgroundColor: context.knobs.options(
+          label: 'Background Color',
+          initial: null,
+          options: [
+            const Option(label: 'Default', value: null),
+            Option(label: 'Purple', value: Colors.purple.shade100),
+            Option(label: 'Pink', value: Colors.pink.shade100),
+            Option(label: 'Indigo', value: Colors.indigo.shade100),
+            Option(label: 'Teal', value: Colors.teal.shade100),
+          ],
+        ),
+        customTextColor: context.knobs.options(
+          label: 'Text Color',
+          initial: null,
+          options: [
+            const Option(label: 'Default', value: null),
+            Option(label: 'Purple', value: Colors.purple.shade800),
+            Option(label: 'Pink', value: Colors.pink.shade800),
+            Option(label: 'Indigo', value: Colors.indigo.shade800),
+            Option(label: 'Teal', value: Colors.teal.shade800),
+          ],
+        ),
+        customBorderColor: context.knobs.options(
+          label: 'Border Color',
+          initial: null,
+          options: [
+            const Option(label: 'Default', value: null),
+            Option(label: 'Purple', value: Colors.purple.shade300),
+            Option(label: 'Pink', value: Colors.pink.shade300),
+            Option(label: 'Indigo', value: Colors.indigo.shade300),
+            Option(label: 'Teal', value: Colors.teal.shade300),
+          ],
+        ),
+        
+        // Interactive Controls
+        enableInteraction: context.knobs.boolean(
+          label: 'Enable Tap Interaction',
+          initial: true,
+        ),
+        
+        maxCount: context.knobs.options(
+          label: 'Max Count',
+          initial: null,
+          options: const [
+            Option(label: 'None', value: null),
+            Option(label: '9', value: 9),
+            Option(label: '99', value: 99),
+            Option(label: '999', value: 999),
+          ],
+        ),
+        
+        showZero: context.knobs.boolean(
+          label: 'Show Zero Count',
+          initial: true,
+        ),
+        
+        // Layout Options (minimal for clean UI)
+        spacing: 16.0,
+        parentType: 'None',
+      ),
+    ),
+  ];
+}

--- a/packages/components/example_storybook/lib/storybook_test/components/badge_test_modular/utils/badge_builder.dart
+++ b/packages/components/example_storybook/lib/storybook_test/components/badge_test_modular/utils/badge_builder.dart
@@ -1,0 +1,163 @@
+import 'package:flutter/material.dart';
+import 'package:osmea_components/osmea_components.dart';
+
+/// 🏷️ **Badge Builder Utility**
+/// 
+/// Helper utilities for badge construction and configuration
+
+class BadgeBuilder {
+  /// Convert enum to string representation
+  static String enumToString(dynamic enumValue) {
+    return enumValue.toString().split('.').last;
+  }
+
+  /// Format enum names for display
+  static String formatEnumName(String enumName) {
+    // Convert camelCase to Title Case
+    return enumName
+        .replaceAllMapped(RegExp(r'([A-Z])'), (match) => ' ${match.group(1)}')
+        .trim()
+        .split(' ')
+        .map((word) => word[0].toUpperCase() + word.substring(1).toLowerCase())
+        .join(' ');
+  }
+
+  /// Build badge with common parameters
+  static Widget buildBadge({
+    required BadgeSize size,
+    required BadgeVariant variant,
+    required BadgeStyle style,
+    required BadgeState state,
+    required BadgeShape shape,
+    BadgePosition position = BadgePosition.standalone,
+    dynamic content,
+    Widget? child,
+    Color? backgroundColor,
+    Color? textColor,
+    Color? borderColor,
+    VoidCallback? onTap,
+    int? maxCount,
+    bool showZero = false,
+    Offset? offset,
+    EdgeInsets? padding,
+  }) {
+    return OsmeaComponents.badge(
+      size: size,
+      variant: variant,
+      style: style,
+      state: state,
+      shape: shape,
+      position: position,
+      content: content,
+      child: child,
+      backgroundColor: backgroundColor,
+      textColor: textColor,
+      borderColor: borderColor,
+      onTap: onTap,
+      maxCount: maxCount,
+      showZero: showZero,
+      offset: offset,
+      padding: padding,
+    );
+  }
+
+  /// Get sample content for different badge types
+  static List<String> getSampleBadgeTexts() {
+    return ['New', '42', 'Hot', 'Sale', 'Pro', 'Beta', '99+', 'VIP'];
+  }
+
+  /// Get sample numbers for count badges
+  static List<int> getSampleCounts() {
+    return [1, 5, 12, 42, 99, 150, 999, 1250];
+  }
+
+  /// Create a sample child widget for positioned badges
+  static Widget createSampleChild({
+    double width = 60,
+    double height = 60,
+    IconData icon = Icons.notifications,
+    Color? backgroundColor,
+  }) {
+    return Container(
+      width: width,
+      height: height,
+      decoration: BoxDecoration(
+        color: backgroundColor ?? Colors.grey.shade200,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Icon(
+        icon,
+        size: 24,
+        color: Colors.black54,
+      ),
+    );
+  }
+
+  /// Create a sample avatar for avatar badges
+  static Widget createSampleAvatar({double radius = 24}) {
+    return CircleAvatar(
+      radius: radius,
+      backgroundColor: OsmeaColors.nordicBlue,
+      child: Icon(
+        Icons.person,
+        color: Colors.white,
+        size: radius * 0.8,
+      ),
+    );
+  }
+
+  /// Create a sample button for button badges
+  static Widget createSampleButton({
+    required String text,
+    VoidCallback? onPressed,
+  }) {
+    return ElevatedButton(
+      onPressed: onPressed ?? () {},
+      style: ElevatedButton.styleFrom(
+        backgroundColor: OsmeaColors.white,
+        foregroundColor: OsmeaColors.nordicBlue,
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(8),
+        ),
+      ),
+      child: Text(text),
+    );
+  }
+
+  /// Get demonstration scenarios for badges
+  static List<Map<String, dynamic>> getBadgeScenarios() {
+    return [
+      {
+        'title': 'Notification Badge',
+        'description': 'Icon with count badge',
+        'widget': 'icon',
+        'icon': Icons.notifications,
+        'defaultContent': 8,
+        'defaultPosition': BadgePosition.topRight,
+      },
+      {
+        'title': 'Avatar Badge',
+        'description': 'User avatar with status',
+        'widget': 'avatar',
+        'defaultContent': 3,
+        'defaultPosition': BadgePosition.bottomRight,
+      },
+      {
+        'title': 'Button Badge',
+        'description': 'Button with notification',
+        'widget': 'button',
+        'text': 'Messages',
+        'defaultContent': 12,
+        'defaultPosition': BadgePosition.topRight,
+      },
+      {
+        'title': 'Standalone Badge',
+        'description': 'Independent badge',
+        'widget': 'none',
+        'defaultContent': 'New',
+        'defaultPosition': BadgePosition.standalone,
+      },
+    ];
+  }
+}

--- a/packages/components/example_storybook/lib/storybook_test/components/badge_test_modular/widgets/section_container_widget.dart
+++ b/packages/components/example_storybook/lib/storybook_test/components/badge_test_modular/widgets/section_container_widget.dart
@@ -1,0 +1,86 @@
+import 'package:flutter/material.dart';
+import 'package:osmea_components/osmea_components.dart';
+
+/// 📦 **Section Container Widget**
+/// 
+/// Reusable container for organizing badge showcases into sections
+
+class SectionContainerWidget extends StatelessWidget {
+  final String title;
+  final bool showTitle;
+  final double spacing;
+  final List<Widget> children;
+  final bool isDark;
+  final CrossAxisAlignment? crossAxisAlignment;
+  final MainAxisAlignment? mainAxisAlignment;
+  final bool wrapContent;
+
+  const SectionContainerWidget({
+    Key? key,
+    required this.title,
+    this.showTitle = true,
+    this.spacing = 16.0,
+    required this.children,
+    this.isDark = false,
+    this.crossAxisAlignment,
+    this.mainAxisAlignment,
+    this.wrapContent = true,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final titleColor = isDark ? Colors.white : OsmeaColors.nordicBlue;
+    final backgroundColor = isDark ? Colors.grey.shade800 : Colors.white;
+    final borderColor = isDark ? Colors.grey.shade700 : OsmeaColors.silver;
+
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(20),
+      decoration: BoxDecoration(
+        color: backgroundColor,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: borderColor, width: 1),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.05),
+            blurRadius: 8,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: Column(
+        crossAxisAlignment: crossAxisAlignment ?? CrossAxisAlignment.start,
+        mainAxisAlignment: mainAxisAlignment ?? MainAxisAlignment.start,
+        children: [
+          if (showTitle) ...[
+            Text(
+              title,
+              style: TextStyle(
+                fontSize: 18,
+                fontWeight: FontWeight.bold,
+                color: titleColor,
+              ),
+            ),
+            SizedBox(height: spacing),
+          ],
+          
+          if (wrapContent)
+            Wrap(
+              spacing: spacing,
+              runSpacing: spacing,
+              children: children,
+            )
+          else
+            Column(
+              crossAxisAlignment: crossAxisAlignment ?? CrossAxisAlignment.start,
+              mainAxisAlignment: mainAxisAlignment ?? MainAxisAlignment.start,
+              children: children.map((child) => Padding(
+                padding: EdgeInsets.only(bottom: spacing),
+                child: child,
+              )).toList(),
+            ),
+        ],
+      ),
+    );
+  }
+}

--- a/packages/components/example_storybook/lib/storybook_test/storybook_testing.dart
+++ b/packages/components/example_storybook/lib/storybook_test/storybook_testing.dart
@@ -4,6 +4,7 @@ import 'package:provider/provider.dart';
 
 // Import individual component showcases directly
 import 'components/avatar_test_modular/showcase/unified_avatar_showcase.dart';
+import 'components/badge_test_modular/showcase/unified_badge_showcase.dart';
 import 'components/button_test_modular/showcase/unified_button_showcase.dart';
 import 'components/navbar_test_modular/showcase/unified_navbar_showcase.dart';
 import 'components/appbar_test_modular/showcase/unified_appbar_showcase.dart';
@@ -72,6 +73,15 @@ List<Story> getComponentStories() {
   return [
     // Avatar component stories
     ...getUnifiedAvatarShowcase().map(
+      (story) => Story(
+        name: StoryConfig.buildComponentStoryName(story.name),
+        description: story.description,
+        builder: story.builder,
+      ),
+    ),
+    
+    // Badge component stories
+    ...getUnifiedBadgeShowcase().map(
       (story) => Story(
         name: StoryConfig.buildComponentStoryName(story.name),
         description: story.description,


### PR DESCRIPTION
## 📋 PR Description

This PR introduces the **Badge Component Stories – Modular Structure** to the example Storybook found in `packages/components/example_storybook`.  

Key points:
- Adds a new modular folder `badge_test_modular/` containing all badge–related stories.
- Implements a **Unified Badge Showcase** (`showcase/unified_badge_showcase.dart`) that displays every badge size, variant, style, state, shape and position in a single story.
- Provides rich Storybook knobs for real-time control of badge properties including custom colours, content type, icons, maximum count, and interactivity.
- Removes the need for multiple individual badge stories by consolidating them into one showcase entry, simplifying maintenance and improving discoverability.
- Follows the established modular template (sections/, showcase/, utils/, widgets/, data/).

---

## ✅ Checklist

- [x] Code follows the project standards and guidelines.
- [ ] Relevant unit tests are written and all tests are passing.
- [x] Test coverage is adequate for the changes.
- [x] Any unnecessary files or debug statements have been removed.
- [x] Documentation is updated where necessary.
- [x] The PR has been reviewed by at least one team member before merging.

---

## 🛠 Steps to Test

1. Run `flutter pub get` in `packages/components/example_storybook` to fetch dependencies.
2. Launch the Storybook: `flutter run -d chrome -t lib/main.dart` (or your preferred device).
3. In the Storybook UI, navigate to **Badges**.
4. Use the knobs in the addon panel to adjust size, variant, style, state, shape, position, content, icon, custom colours, interaction flag, and max count.
5. Confirm that the badge updates in real-time according to the selected knobs and that there are no visual or functional regressions.

---

### 📷 Screenshots (Optional)

|  |  |
| --- | --- |
|![Screenshot 2025-07-04 at 19 25 38](https://github.com/user-attachments/assets/ec30029a-8f56-4382-80e2-1b403afe2bc9) | ![Screenshot 2025-07-04 at 19 26 27](https://github.com/user-attachments/assets/4ff26872-26da-405c-9427-ed427a8b344f) |
| ![Screenshot 2025-07-04 at 19 27 01](https://github.com/user-attachments/assets/93ae1d68-7cb7-49f9-a9db-786eef597667) | ![Screenshot 2025-07-04 at 19 28 15](https://github.com/user-attachments/assets/0b3b2521-a59c-4819-86c4-2c0758651069) | 