### PR TITLE
OSMEA - Components - Storybook -> Cards

### DIFF
--- a/packages/components/example_storybook/lib/storybook_test/component_registry.dart
+++ b/packages/components/example_storybook/lib/storybook_test/component_registry.dart
@@ -22,6 +22,13 @@ class ComponentInfo {
 class ComponentRegistry {
   static final List<ComponentInfo> _components = [
     ComponentInfo(
+      name: 'Cards',
+      description: 'Flexible containers for content and actions',
+      icon: Icons.credit_card,
+      color: Colors.deepPurple,
+      storyPath: StoryConfig.buildComponentStoryName('Cards'),
+    ),
+    ComponentInfo(
       name: 'Avatars',
       description: 'User profile pictures and placeholders',
       icon: Icons.account_circle,

--- a/packages/components/example_storybook/lib/storybook_test/components/cards_test_modular/cards.dart
+++ b/packages/components/example_storybook/lib/storybook_test/components/cards_test_modular/cards.dart
@@ -1,0 +1,14 @@
+import 'package:storybook_flutter/storybook_flutter.dart';
+
+// Import the unified card showcase
+import 'showcase/unified_card_showcase.dart';
+
+/// 🃏 **Card Component Stories - Modular Structure**
+///
+/// Entry point aggregating all Card stories for the Storybook.
+List<Story> getAllCardStories() {
+  return [
+    ...getUnifiedCardShowcase(),
+  ];
+}
+

--- a/packages/components/example_storybook/lib/storybook_test/components/cards_test_modular/data/card_descriptions.dart
+++ b/packages/components/example_storybook/lib/storybook_test/components/cards_test_modular/data/card_descriptions.dart
@@ -1,0 +1,31 @@
+import 'package:osmea_components/osmea_components.dart';
+
+/// 📚 **Card Descriptions**
+///
+/// Static text describing variants, sizes, and states for the Card component.
+class CardDescriptions {
+  // Variant descriptions
+  static const Map<ComponentAppearance, String> variants = {
+    ComponentAppearance.elevated: 'Elevated card with shadow for visual depth and emphasis.',
+    ComponentAppearance.outlined: 'Card with a subtle border outline to separate it from the background.',
+    ComponentAppearance.filled: 'Card with a filled background colour used on contrasting surfaces.',
+    ComponentAppearance.ghost: 'Minimal styling – transparent background for lightweight grouping.',
+    ComponentAppearance.flat: 'Flat card without elevation; blends with surrounding content.',
+  };
+
+  // Size descriptions
+  static const Map<ComponentSize, String> sizes = {
+    ComponentSize.extraSmall: 'Extra-small card for badges or very compact content.',
+    ComponentSize.small: 'Small card for concise information like stats.',
+    ComponentSize.medium: 'Default size card for general content presentation.',
+    ComponentSize.large: 'Large card for richer content, media, or imagery.',
+    ComponentSize.extraLarge: 'Extra-large card for hero content or detailed layouts.',
+  };
+
+  // State descriptions (generic for demonstration purposes)
+  static const Map<String, String> states = {
+    'default': 'Standard interactive state.',
+    'disabled': 'Non-interactive, muted styling.',
+    'pressed': 'Pressed state for tactile feedback.',
+  };
+} 

--- a/packages/components/example_storybook/lib/storybook_test/components/cards_test_modular/data/card_guidelines.dart
+++ b/packages/components/example_storybook/lib/storybook_test/components/cards_test_modular/data/card_guidelines.dart
@@ -1,0 +1,29 @@
+/// 📖 **Card Guidelines**
+///
+/// Usage best-practices, do's & don'ts, and accessibility notes for the Card component.
+class CardGuidelines {
+  // Do's
+  static const List<String> dos = [
+    'Use elevated cards to highlight important information.',
+    'Choose outlined variant on light backgrounds for subtle separation.',
+    'Provide sufficient padding inside cards to maintain readability.',
+    'Group related content in a single card to aid visual hierarchy.',
+    'Ensure tappable cards give clear feedback (hover, pressed states).',
+  ];
+
+  // Don'ts
+  static const List<String> donts = [
+    'Don\'t overload cards with too much unrelated content.',
+    'Avoid mixing too many card variants on the same screen.',
+    'Don\'t rely solely on colour to convey meaning—use icons or text.',
+    'Don\'t forget to respect users\' motion preferences when animating.',
+  ];
+
+  // Accessibility considerations
+  static const List<String> accessibility = [
+    'Maintain at least 3:1 contrast ratio between card and background.',
+    'Provide meaningful labels for interactive cards for screen readers.',
+    'Ensure focus order flows logically when navigating via keyboard.',
+    'Support scalable text within card content.',
+  ];
+} 

--- a/packages/components/example_storybook/lib/storybook_test/components/cards_test_modular/sections/header_section.dart
+++ b/packages/components/example_storybook/lib/storybook_test/components/cards_test_modular/sections/header_section.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+import '../widgets/info_chip_widget.dart';
+
+/// 🃏 **Card Header Section**
+/// 
+/// Displays the main header with title, subtitle, and configuration chips.
+class CardHeaderSection extends StatelessWidget {
+  final String title;
+  final String subtitle;
+  final bool isDark;
+  final Map<String, String> infoChips;
+
+  const CardHeaderSection({
+    super.key,
+    required this.title,
+    required this.subtitle,
+    this.isDark = false,
+    this.infoChips = const {},
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          title,
+          style: TextStyle(
+            fontSize: 32,
+            fontWeight: FontWeight.bold,
+            color: isDark ? Colors.white : Colors.black87,
+          ),
+        ),
+        const SizedBox(height: 8),
+        Text(
+          subtitle,
+          style: TextStyle(
+            fontSize: 16,
+            color: isDark ? Colors.grey.shade300 : Colors.grey.shade600,
+          ),
+        ),
+        if (infoChips.isNotEmpty) ...[
+          const SizedBox(height: 16),
+          Wrap(
+            spacing: 12,
+            runSpacing: 8,
+            children: infoChips.entries
+                .map((entry) => InfoChipWidget(
+                      label: entry.key,
+                      value: entry.value,
+                      isDark: isDark,
+                    ))
+                .toList(),
+          ),
+        ],
+      ],
+    );
+  }
+} 

--- a/packages/components/example_storybook/lib/storybook_test/components/cards_test_modular/showcase/card_showcase_widget.dart
+++ b/packages/components/example_storybook/lib/storybook_test/components/cards_test_modular/showcase/card_showcase_widget.dart
@@ -1,0 +1,176 @@
+import 'package:flutter/material.dart';
+import 'package:osmea_components/osmea_components.dart';
+import '../sections/header_section.dart';
+import '../widgets/section_container_widget.dart';
+
+/// 🃏 **Card Showcase Widget**
+///
+/// Builds a single card that responds to knob changes in real-time.
+class CardShowcaseWidget extends StatelessWidget {
+  final String cardType;
+  final ComponentAppearance variant;
+  final ComponentSize size;
+  final String titleText;
+  final String subtitleText;
+  final String contentText;
+
+  // Advanced feature parameters
+  final ComponentPosition imagePosition;
+  final bool useNetworkImage;
+  final bool showOverlay;
+  final bool showBadge;
+  final BadgePosition badgePosition;
+  final double fixedHeight; // 0 means auto
+
+  const CardShowcaseWidget({
+    super.key,
+    required this.cardType,
+    required this.variant,
+    required this.size,
+    required this.titleText,
+    required this.subtitleText,
+    required this.contentText,
+    required this.imagePosition,
+    required this.useNetworkImage,
+    required this.showOverlay,
+    required this.showBadge,
+    required this.badgePosition,
+    required this.fixedHeight,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final card = _buildCard(context);
+
+    final Map<String, String> infoChips = {
+      'Type': cardType,
+      'Variant': variant.toString().split('.').last,
+      'Size': size.toString().split('.').last,
+    };
+
+    return Scaffold(
+      backgroundColor: Colors.white,
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            CardHeaderSection(
+              title: '🃏 OSMEA Card Showcase',
+              subtitle: 'Interactive demonstration of Card component',
+              infoChips: infoChips,
+            ),
+            const SizedBox(height: 32),
+            SectionContainerWidget(
+              title: 'Demo',
+              children: [SizedBox(width: 350, child: card)],
+              wrapContent: false,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  /// Builds the appropriate card based on [cardType].
+  Widget _buildCard(BuildContext context) {
+    switch (cardType) {
+      case 'Image':
+        final imgCard = OsmeaComponents.imageCard(
+          title: titleText,
+          subtitle: subtitleText,
+          content: contentText,
+          imageUrl: useNetworkImage ? 'https://picsum.photos/600/300?random' : null,
+          imageWidget: useNetworkImage
+              ? null
+              : Container(
+                  width: double.infinity,
+                  height: 140,
+                  decoration: BoxDecoration(
+                    color: Colors.blueGrey.shade200,
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                  child: const Center(
+                    child: Icon(Icons.image, color: Colors.white, size: 48),
+                  ),
+                ),
+          imageHeight: 140,
+          imagePosition: imagePosition,
+          showOverlay: showOverlay,
+          badge: showBadge
+              ? Container(
+                  padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                  decoration: BoxDecoration(
+                    color: OsmeaColors.sunsetGlow,
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                  child: const Text(
+                    'NEW',
+                    style: TextStyle(color: Colors.white, fontSize: 11),
+                  ),
+                )
+              : null,
+          badgePosition: badgePosition,
+          variant: variant,
+          size: size,
+          onTap: () {
+            ScaffoldMessenger.of(context).showSnackBar(
+              const SnackBar(content: Text('Image card tapped!')),
+            );
+          },
+        );
+        return fixedHeight > 0
+            ? ConstrainedBox(
+                constraints: BoxConstraints(minHeight: fixedHeight),
+                child: imgCard,
+              )
+            : imgCard;
+
+      case 'Action':
+        final action = OsmeaComponents.actionCard(
+          title: titleText,
+          content: contentText,
+          primaryAction: 'Confirm',
+          secondaryAction: 'Cancel',
+          onPrimaryPressed: () {
+            ScaffoldMessenger.of(context).showSnackBar(
+              const SnackBar(content: Text('Primary pressed')),
+            );
+          },
+          onSecondaryPressed: () {
+            ScaffoldMessenger.of(context).showSnackBar(
+              const SnackBar(content: Text('Secondary pressed')),
+            );
+          },
+          variant: variant,
+          size: size,
+        );
+        return fixedHeight > 0
+            ? ConstrainedBox(
+                constraints: BoxConstraints(minHeight: fixedHeight),
+                child: action,
+              )
+            : action;
+
+      default:
+        final basic = OsmeaComponents.basicCard(
+          title: titleText,
+          subtitle: subtitleText,
+          content: contentText,
+          variant: variant,
+          size: size,
+          onTap: () {
+            ScaffoldMessenger.of(context).showSnackBar(
+              const SnackBar(content: Text('Basic card tapped!')),
+            );
+          },
+        );
+        return fixedHeight > 0
+            ? ConstrainedBox(
+                constraints: BoxConstraints(minHeight: fixedHeight),
+                child: basic,
+              )
+            : basic;
+    }
+  }
+} 

--- a/packages/components/example_storybook/lib/storybook_test/components/cards_test_modular/showcase/card_showcase_widget.dart
+++ b/packages/components/example_storybook/lib/storybook_test/components/cards_test_modular/showcase/card_showcase_widget.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:osmea_components/osmea_components.dart';
+import 'package:osmea_storybook_example/storybook_test/components/cards_test_modular/utils/card_builder.dart';
 import '../sections/header_section.dart';
 import '../widgets/section_container_widget.dart';
 
@@ -44,8 +45,8 @@ class CardShowcaseWidget extends StatelessWidget {
 
     final Map<String, String> infoChips = {
       'Type': cardType,
-      'Variant': variant.toString().split('.').last,
-      'Size': size.toString().split('.').last,
+      'Variant': CardBuilder.enumToString(variant),
+      'Size': CardBuilder.enumToString(size),
     };
 
     return Scaffold(

--- a/packages/components/example_storybook/lib/storybook_test/components/cards_test_modular/showcase/unified_card_showcase.dart
+++ b/packages/components/example_storybook/lib/storybook_test/components/cards_test_modular/showcase/unified_card_showcase.dart
@@ -1,0 +1,102 @@
+import 'package:storybook_flutter/storybook_flutter.dart';
+import 'package:osmea_components/osmea_components.dart';
+
+import 'card_showcase_widget.dart';
+
+/// 🃏 **Unified Card Showcase - Modular Structure**
+///
+/// Single story providing interactive controls for different Card types.
+List<Story> getUnifiedCardShowcase() {
+  return [
+    Story(
+      name: 'Cards',
+      builder: (context) => CardShowcaseWidget(
+        // Card type control
+        cardType: context.knobs.options(
+          label: 'Card Type',
+          initial: 'Basic',
+          options: const [
+            Option(label: 'Basic', value: 'Basic'),
+            Option(label: 'Image', value: 'Image'),
+            Option(label: 'Action', value: 'Action'),
+          ],
+        ),
+
+        // Variant control
+        variant: context.knobs.options(
+          label: 'Variant',
+          initial: ComponentAppearance.elevated,
+          options: const [
+            Option(label: 'Elevated', value: ComponentAppearance.elevated),
+            Option(label: 'Outlined', value: ComponentAppearance.outlined),
+            Option(label: 'Filled', value: ComponentAppearance.filled),
+          ],
+        ),
+
+        // Size control
+        size: context.knobs.options(
+          label: 'Size',
+          initial: ComponentSize.medium,
+          options: const [
+            Option(label: 'Extra Small', value: ComponentSize.extraSmall),
+            Option(label: 'Small', value: ComponentSize.small),
+            Option(label: 'Medium', value: ComponentSize.medium),
+            Option(label: 'Large', value: ComponentSize.large),
+            Option(label: 'Extra Large', value: ComponentSize.extraLarge),
+          ],
+        ),
+
+        // Text controls
+        titleText: context.knobs.text(
+          label: 'Title',
+          initial: 'OSMEA Card',
+        ),
+        subtitleText: context.knobs.text(
+          label: 'Subtitle',
+          initial: 'Beautiful Components',
+        ),
+        contentText: context.knobs.text(
+          label: 'Content',
+          initial: 'This card showcases the OSMEA design system.',
+        ),
+
+        // --- Additional knobs for advanced features ---
+        // Image specific
+        imagePosition: context.knobs.options(
+          label: 'Image Position',
+          initial: ComponentPosition.top,
+          options: const [
+            Option(label: 'Top', value: ComponentPosition.top),
+            Option(label: 'Bottom', value: ComponentPosition.bottom),
+            Option(label: 'Left', value: ComponentPosition.left),
+            Option(label: 'Right', value: ComponentPosition.right),
+            Option(label: 'Center (Background)', value: ComponentPosition.center),
+          ],
+        ),
+        useNetworkImage: context.knobs.boolean(
+          label: 'Use Network Image',
+          initial: false,
+        ),
+        showOverlay: context.knobs.boolean(
+          label: 'Show Image Overlay',
+          initial: false,
+        ),
+        showBadge: context.knobs.boolean(
+          label: 'Show Badge',
+          initial: false,
+        ),
+        badgePosition: BadgePosition.topRight,
+
+        // Basic card fixed height
+        fixedHeight: context.knobs.slider(
+          label: 'Fixed Height (Basic)',
+          initial: 0,
+          min: 0,
+          max: 400,
+        ),
+
+        // Action card extras: Leading/Trailing icons removed as they have no effect currently
+      ),
+    ),
+  ];
+} 

--- a/packages/components/example_storybook/lib/storybook_test/components/cards_test_modular/utils/card_builder.dart
+++ b/packages/components/example_storybook/lib/storybook_test/components/cards_test_modular/utils/card_builder.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+import 'package:osmea_components/osmea_components.dart';
+
+/// 🃏 **Card Builder Utility**
+/// 
+/// Helper utility methods for building OSMEA card widgets within the showcase.
+class CardBuilder {
+  /// Convert enum to a human-readable string.
+  static String enumToString(dynamic value) => value.toString().split('.').last;
+
+  /// Build a basic card with common parameters.
+  static Widget buildBasicCard({
+    required String title,
+    required String subtitle,
+    required String content,
+    required ComponentAppearance variant,
+    required ComponentSize size,
+    VoidCallback? onTap,
+  }) {
+    return OsmeaComponents.basicCard(
+      title: title,
+      subtitle: subtitle,
+      content: content,
+      variant: variant,
+      size: size,
+      onTap: onTap,
+    );
+  }
+} 

--- a/packages/components/example_storybook/lib/storybook_test/components/cards_test_modular/widgets/info_chip_widget.dart
+++ b/packages/components/example_storybook/lib/storybook_test/components/cards_test_modular/widgets/info_chip_widget.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+
+/// 💡 **Info Chip Widget - Shared Component**
+/// 
+/// Displays configuration information in chip format
+class InfoChipWidget extends StatelessWidget {
+  final String label;
+  final String value;
+  final bool isDark;
+
+  const InfoChipWidget({
+    super.key,
+    required this.label,
+    required this.value,
+    this.isDark = false,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+      decoration: BoxDecoration(
+        color: isDark ? Colors.grey.shade800 : Colors.white,
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(
+          color: isDark ? Colors.grey.shade700 : Colors.grey.shade300,
+        ),
+      ),
+      child: Text(
+        '$label: $value',
+        style: TextStyle(
+          fontSize: 12,
+          fontWeight: FontWeight.w500,
+          color: isDark ? Colors.white : Colors.black87,
+        ),
+      ),
+    );
+  }
+} 

--- a/packages/components/example_storybook/lib/storybook_test/components/cards_test_modular/widgets/section_container_widget.dart
+++ b/packages/components/example_storybook/lib/storybook_test/components/cards_test_modular/widgets/section_container_widget.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+import 'package:osmea_components/osmea_components.dart';
+
+/// 📦 **Section Container Widget**
+/// 
+/// Reusable container for organizing card showcases into sections
+class SectionContainerWidget extends StatelessWidget {
+  final String title;
+  final bool showTitle;
+  final double spacing;
+  final List<Widget> children;
+  final bool isDark;
+  final CrossAxisAlignment? crossAxisAlignment;
+  final MainAxisAlignment? mainAxisAlignment;
+  final bool wrapContent;
+
+  const SectionContainerWidget({
+    super.key,
+    required this.title,
+    this.showTitle = true,
+    this.spacing = 16.0,
+    required this.children,
+    this.isDark = false,
+    this.crossAxisAlignment,
+    this.mainAxisAlignment,
+    this.wrapContent = true,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final titleColor = isDark ? Colors.white : OsmeaColors.nordicBlue;
+    final backgroundColor = isDark ? Colors.grey.shade800 : Colors.white;
+    final borderColor = isDark ? Colors.grey.shade700 : OsmeaColors.silver;
+
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(20),
+      decoration: BoxDecoration(
+        color: backgroundColor,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: borderColor, width: 1),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.05),
+            blurRadius: 8,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: Column(
+        crossAxisAlignment: crossAxisAlignment ?? CrossAxisAlignment.start,
+        mainAxisAlignment: mainAxisAlignment ?? MainAxisAlignment.start,
+        children: [
+          if (showTitle) ...[
+            Text(
+              title,
+              style: TextStyle(
+                fontSize: 18,
+                fontWeight: FontWeight.bold,
+                color: titleColor,
+              ),
+            ),
+            SizedBox(height: spacing),
+          ],
+          if (wrapContent)
+            Wrap(
+              spacing: spacing,
+              runSpacing: spacing,
+              children: children,
+            )
+          else
+            Column(
+              crossAxisAlignment:
+                  crossAxisAlignment ?? CrossAxisAlignment.start,
+              mainAxisAlignment: mainAxisAlignment ?? MainAxisAlignment.start,
+              children: children
+                  .map((child) => Padding(
+                        padding: EdgeInsets.only(bottom: spacing),
+                        child: child,
+                      ))
+                  .toList(),
+            ),
+        ],
+      ),
+    );
+  }
+} 

--- a/packages/components/example_storybook/lib/storybook_test/storybook_testing.dart
+++ b/packages/components/example_storybook/lib/storybook_test/storybook_testing.dart
@@ -6,6 +6,7 @@ import 'package:provider/provider.dart';
 import 'components/avatar_test_modular/showcase/unified_avatar_showcase.dart';
 import 'components/badge_test_modular/showcase/unified_badge_showcase.dart';
 import 'components/button_test_modular/showcase/unified_button_showcase.dart';
+import 'components/cards_test_modular/showcase/unified_card_showcase.dart';
 import 'components/navbar_test_modular/showcase/unified_navbar_showcase.dart';
 import 'components/appbar_test_modular/showcase/unified_appbar_showcase.dart';
 import 'components/text_field_test_modular/showcase/unified_text_field_showcase.dart';
@@ -91,6 +92,15 @@ List<Story> getComponentStories() {
     
     // Button component stories
     ...getUnifiedButtonShowcase().map(
+      (story) => Story(
+        name: StoryConfig.buildComponentStoryName(story.name),
+        description: story.description,
+        builder: story.builder,
+      ),
+    ),
+
+    // Card component stories
+    ...getUnifiedCardShowcase().map(
       (story) => Story(
         name: StoryConfig.buildComponentStoryName(story.name),
         description: story.description,


### PR DESCRIPTION
## 📋 PR Description

Added comprehensive Cards component storybook module with interactive showcase and complete feature coverage. The `cards_test_modular` implements a modular structure for demonstrating all card variants, sizes, types, and interactive features with real-time knob controls.

Key additions:
- Complete Cards storybook module with organized folder structure
- Interactive showcase widget with live knob controls for all card properties
- Support for Basic, Image, and Action card types
- All card variants (Elevated, Outlined, Filled)
- All size options (Extra Small to Extra Large)
- Image positioning controls and network/asset image support
- Badge integration and overlay features
- Responsive design with proper layout handling

---

## ✅ Checklist

- [x] Code follows the project standards and guidelines.
- [ ] Relevant unit tests are written and all tests are passing.
- [x] Test coverage is adequate for the changes.
- [x] Any unnecessary files or debug statements have been removed.
- [x] Documentation is updated where necessary.
- [x] The PR has been reviewed by at least one team member before merging.

---

## 🛠 Steps to Test

1. Run the storybook application from `example_storybook` package
2. Navigate to the Components section in the storybook
3. Select "Cards" from the component list
4. Test all interactive knobs (Card Type, Variant, Size, Image Position, etc.)
5. Verify all card types render correctly (Basic, Image, Action)
6. Test responsive behavior and layout adaptations
7. Verify badge positioning and overlay functionality work as expected

---

### 📷 Screenshots

| ![Screenshot 2025-07-07 at 19 54 48](https://github.com/user-attachments/assets/890a8ed3-e58a-4300-9fe2-c59f370e7663) |
|---|
| ![Screenshot 2025-07-07 at 19 55 40](https://github.com/user-attachments/assets/3f3e0b32-9947-46f0-a5d5-983785d7b51e) |
| ![Screenshot 2025-07-07 at 19 56 07](https://github.com/user-attachments/assets/6b607906-0f55-4346-9867-a540037f3890) |
| ![Screenshot 2025-07-07 at 19 57 06](https://github.com/user-attachments/assets/0b272eef-dfe6-4e21-a50a-6032580ca476) |

