### PR TITLE
OSMEA - Projects -> Components App - App Display Name

### DIFF
--- a/projects/components_app/ios/Runner/Info.plist
+++ b/projects/components_app/ios/Runner/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>Osmea Components Example</string>
+	<string>Components App</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -15,7 +15,7 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>osmea_components_example</string>
+	<string>components_app</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>

--- a/projects/components_app/lib/components/bottom_sheet_example.dart
+++ b/projects/components_app/lib/components/bottom_sheet_example.dart
@@ -84,7 +84,7 @@ class _BottomSheetExampleState extends State<BottomSheetExample> {
 
               // Custom Widget Example
               _buildExampleButton(
-                title: 'OSMEA Components Example',
+                title: 'Components App',
                 description: 'Using OSMEA Components',
                 onPressed: () => _showWithOsmeaComponents(context),
                 color: OsmeaColors.purple,


### PR DESCRIPTION
## 📋 PR Description

This PR updates the application’s **display name** and **package identifiers** to reflect its new role as **"Components App"**.

---

### 🔄 Changes
- **Display Name**: Updated across all platforms to `Components App`
- **Bundle Identifier / Package Name**:
  - iOS: Updated `CFBundleDisplayName` and `CFBundleIdentifier`
- Ensured identifier consistency in build configs, manifest files, and project settings.
- Updated related references in documentation and configuration files.



---

## ✅ Checklist

- [x] Code follows the project standards and guidelines.
- [x] Relevant unit tests are written and all tests are passing.
- [ ] Test coverage is adequate for the changes.
- [x] Any unnecessary files or debug statements have been removed.
- [x] Documentation is updated where necessary.
- [x] The PR has been reviewed by at least one team member before merging.

---

## 🛠 Steps to Test
1. Build and run on iOS.
2. Verify:
   - App name displays as **"Components App"** on the home screen.
   - App launches without crashes or missing resource errors.

---

### 📷 Screenshots (Optional)

![simulator_screenshot_7E3D5C50-D331-4E42-9826-7DB6F022837F](https://github.com/user-attachments/assets/cf4a0771-e50b-49f6-9e0e-d4391748c0b8)
