### PR TITLE
OSMEA - Components - Storybook -> Snackbar

### DIFF
--- a/packages/components/lib/src/components/snackbar/snackbar.dart
+++ b/packages/components/lib/src/components/snackbar/snackbar.dart
@@ -123,20 +123,67 @@ class _PositionedSnackbarGroup extends StatelessWidget {
               children: displaySnackbars.asMap().entries.map((entry) {
                 final index = entry.key;
                 final snackbar = entry.value;
-                return Positioned(
-                  bottom: index * 8.0,
-                  left: 0,
-                  right: 0,
-                  child: Transform.translate(
-                    offset: Offset(0, -index * 2.0),
-                    child: OsmeaSnackbar(
-                      key: ValueKey(snackbar.id),
-                      state: snackbar,
-                      onClose: () =>
-                          SnackbarManager().hideSnackbar(snackbar.id),
-                    ),
-                  ),
-                );
+                
+                // Different positioning logic for different positions
+                Widget positionedSnackbar;
+                switch (position) {
+                  case SnackbarPosition.top:
+                    positionedSnackbar = Positioned(
+                      top: index * 8.0,
+                      left: 0,
+                      right: 0,
+                      child: Transform.translate(
+                        offset: Offset(0, index * 2.0),
+                        child: OsmeaSnackbar(
+                          key: ValueKey(snackbar.id),
+                          state: snackbar,
+                          onClose: () =>
+                              SnackbarManager().hideSnackbar(snackbar.id),
+                        ),
+                      ),
+                    );
+                    break;
+                  case SnackbarPosition.center:
+                    // For center position, position relative to center point
+                    // First snackbar at center, subsequent ones offset upward
+                    positionedSnackbar = Positioned(
+                      top: 0,
+                      bottom: 0,
+                      left: 0,
+                      right: 0,
+                      child: Align(
+                        alignment: Alignment.center,
+                        child: Transform.translate(
+                          offset: Offset(0, -index * 10.0), // Stack upward from center
+                          child: OsmeaSnackbar(
+                            key: ValueKey(snackbar.id),
+                            state: snackbar,
+                            onClose: () =>
+                                SnackbarManager().hideSnackbar(snackbar.id),
+                          ),
+                        ),
+                      ),
+                    );
+                    break;
+                  case SnackbarPosition.bottom:
+                    positionedSnackbar = Positioned(
+                      bottom: index * 8.0,
+                      left: 0,
+                      right: 0,
+                      child: Transform.translate(
+                        offset: Offset(0, -index * 2.0),
+                        child: OsmeaSnackbar(
+                          key: ValueKey(snackbar.id),
+                          state: snackbar,
+                          onClose: () =>
+                              SnackbarManager().hideSnackbar(snackbar.id),
+                        ),
+                      ),
+                    );
+                    break;
+                }
+                
+                return positionedSnackbar;
               }).toList(),
             ),
           ),

--- a/projects/storybook/lib/components/snackbar_storybook/data/snackbar_descriptions.dart
+++ b/projects/storybook/lib/components/snackbar_storybook/data/snackbar_descriptions.dart
@@ -1,0 +1,58 @@
+import 'package:osmea_components/osmea_components.dart';
+
+/// 💬 **Snackbar Descriptions**
+/// 
+/// Static descriptions for snackbar variants, positions, and styles
+
+class SnackbarDescriptions {
+  /// Type descriptions
+  static const Map<SnackbarType, String> types = {
+    SnackbarType.success: 'Success messages confirm successful operations and provide positive feedback to users.',
+    SnackbarType.error: 'Error messages alert users to problems and provide guidance on how to resolve them.',
+    SnackbarType.warning: 'Warning messages inform users about potential issues or important considerations.',
+    SnackbarType.info: 'Info messages provide helpful information, updates, or general notifications.',
+  };
+
+  /// Position descriptions
+  static const Map<SnackbarPosition, String> positions = {
+    SnackbarPosition.top: 'Top position displays snackbars at the top of the screen, ideal for important notifications.',
+    SnackbarPosition.bottom: 'Bottom position displays snackbars at the bottom, following Material Design conventions.',
+  };
+
+  /// Animation descriptions
+  static const Map<SnackbarAnimation, String> animations = {
+    SnackbarAnimation.fade: 'Fade animation smoothly transitions opacity for subtle, elegant appearance.',
+    SnackbarAnimation.slide: 'Slide animation moves snackbars in from the edge for dynamic, engaging transitions.',
+    SnackbarAnimation.scale: 'Scale animation grows and shrinks snackbars for attention-grabbing effects.',
+  };
+
+  /// Style descriptions
+  static const Map<SnackbarStyle, String> styles = {
+    SnackbarStyle.defaultStyle: 'Default style provides a clean, standard appearance suitable for most use cases.',
+    SnackbarStyle.modern: 'Modern style features contemporary design elements with enhanced visual appeal.',
+    SnackbarStyle.minimal: 'Minimal style offers a clean, distraction-free appearance for subtle notifications.',
+    SnackbarStyle.outline: 'Outline style uses borders and subtle backgrounds for a lightweight appearance.',
+  };
+
+
+
+  /// Feature descriptions
+  static const Map<String, String> features = {
+    'action_button': 'Action buttons allow users to perform immediate actions without navigating away.',
+    'progress_indicator': 'Progress indicators show operation status and completion percentage.',
+    'auto_dismiss': 'Auto-dismiss functionality automatically hides snackbars after a specified duration.',
+    'stacking': 'Stacking allows multiple snackbars to be displayed simultaneously.',
+    'dismissible': 'Dismissible snackbars can be manually closed by users.',
+    'custom_duration': 'Custom duration allows precise control over how long snackbars are displayed.',
+  };
+
+  /// Use case descriptions
+  static const Map<String, String> useCases = {
+    'form_submission': 'Confirm successful form submissions and provide feedback on data processing.',
+    'error_handling': 'Display error messages when operations fail and guide users to solutions.',
+    'status_updates': 'Show real-time status updates for ongoing operations like file uploads.',
+    'user_actions': 'Confirm user actions like deletions with undo options.',
+    'system_notifications': 'Inform users about system events like maintenance or updates.',
+    'feature_announcements': 'Announce new features or important changes to the application.',
+  };
+}

--- a/projects/storybook/lib/components/snackbar_storybook/data/snackbar_guidelines.dart
+++ b/projects/storybook/lib/components/snackbar_storybook/data/snackbar_guidelines.dart
@@ -1,0 +1,89 @@
+/// 💬 **Snackbar Guidelines**
+/// 
+/// Best practices and usage guidelines for snackbar components
+
+class SnackbarGuidelines {
+  /// Do's - Best practices to follow
+  static const List<String> dos = [
+    'Use success snackbars to confirm completed actions',
+    'Provide clear, actionable error messages with solutions',
+    'Keep messages concise and easy to understand',
+    'Use appropriate snackbar types for different scenarios',
+    'Include action buttons for reversible operations',
+    'Set reasonable auto-dismiss durations (2-6 seconds)',
+    'Use progress indicators for long-running operations',
+    'Position snackbars where they won\'t block important content',
+    'Ensure sufficient color contrast for accessibility',
+    'Test snackbar behavior across different screen sizes',
+  ];
+
+  /// Don'ts - Practices to avoid
+  static const List<String> donts = [
+    'Don\'t use snackbars for critical errors that require immediate attention',
+    'Avoid overly long messages that require scrolling',
+    'Don\'t stack too many snackbars simultaneously',
+    'Avoid using snackbars for primary navigation or complex actions',
+    'Don\'t use snackbars to replace proper error handling',
+    'Avoid inconsistent positioning across your application',
+    'Don\'t use snackbars for information that should be persistent',
+    'Avoid using snackbars for complex forms or multi-step processes',
+    'Don\'t rely solely on color to convey message importance',
+    'Avoid using snackbars for marketing or promotional content',
+  ];
+
+  /// Accessibility guidelines
+  static const List<String> accessibility = [
+    'Ensure sufficient color contrast ratios (4.5:1 minimum)',
+    'Provide alternative text for icons and visual elements',
+    'Support screen reader announcements for snackbar content',
+    'Allow sufficient time for users to read and interact with snackbars',
+    'Provide keyboard navigation support for action buttons',
+    'Use semantic HTML and ARIA labels where applicable',
+    'Test with screen readers and assistive technologies',
+    'Consider users with color vision deficiencies',
+    'Provide clear focus indicators for interactive elements',
+    'Support high contrast mode and system accessibility settings',
+  ];
+
+  /// Implementation tips
+  static const List<String> implementation = [
+    'Use the SnackbarManager for consistent snackbar management',
+    'Configure global snackbar settings for your application',
+    'Implement proper error boundaries around snackbar calls',
+    'Use TypeScript/strong typing for snackbar configurations',
+    'Consider implementing snackbar queuing for multiple notifications',
+    'Test snackbar behavior in different network conditions',
+    'Implement proper cleanup for long-running snackbars',
+    'Use consistent naming conventions for snackbar types',
+    'Consider implementing snackbar analytics for user behavior',
+    'Document snackbar usage patterns in your design system',
+  ];
+
+  /// Common use cases
+  static const List<String> commonUseCases = [
+    'Form submission confirmations and validation errors',
+    'File upload progress and completion status',
+    'Network request success and error handling',
+    'User action confirmations with undo options',
+    'System maintenance and update notifications',
+    'Feature announcements and onboarding tips',
+    'Authentication success and failure messages',
+    'Data synchronization status updates',
+    'Permission request results and explanations',
+    'Application state change notifications',
+  ];
+
+  /// Performance considerations
+  static const List<String> performance = [
+    'Limit the number of concurrent snackbars to prevent UI clutter',
+    'Use efficient animations that don\'t impact frame rates',
+    'Implement proper cleanup to prevent memory leaks',
+    'Consider lazy loading for complex snackbar content',
+    'Optimize snackbar rendering for mobile devices',
+    'Use debouncing for rapid snackbar triggers',
+    'Implement proper error handling to prevent crashes',
+    'Monitor snackbar performance in production',
+    'Consider using virtual scrolling for large snackbar lists',
+    'Test snackbar performance under load conditions',
+  ];
+}

--- a/projects/storybook/lib/components/snackbar_storybook/sections/header_section.dart
+++ b/projects/storybook/lib/components/snackbar_storybook/sections/header_section.dart
@@ -1,0 +1,101 @@
+import 'package:flutter/material.dart';
+import 'package:osmea_components/osmea_components.dart';
+
+/// 💬 **Snackbar Header Section**
+///
+/// Header component for the snackbar showcase with title, subtitle, and info chips
+
+class SnackbarHeaderSection extends StatelessWidget {
+  final String title;
+  final String subtitle;
+  final bool isDark;
+  final Map<String, String> infoChips;
+
+  const SnackbarHeaderSection({
+    Key? key,
+    required this.title,
+    required this.subtitle,
+    this.isDark = false,
+    this.infoChips = const {},
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final titleColor = isDark ? Colors.white : OsmeaColors.nordicBlue;
+    final subtitleColor = isDark ? Colors.grey.shade300 : OsmeaColors.pewter;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        // Main Title
+        Text(
+          title,
+          style: TextStyle(
+            fontSize: 28,
+            fontWeight: FontWeight.bold,
+            color: titleColor,
+          ),
+        ),
+        const SizedBox(height: 8),
+
+        // Subtitle
+        Text(
+          subtitle,
+          style: TextStyle(
+            fontSize: 16,
+            color: subtitleColor,
+            height: 1.4,
+          ),
+        ),
+
+        if (infoChips.isNotEmpty) ...[
+          const SizedBox(height: 16),
+
+          // Info Chips
+          Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            children: infoChips.entries.map((entry) {
+              return Container(
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+                decoration: BoxDecoration(
+                  color: isDark
+                      ? Colors.grey.shade700
+                      : OsmeaColors.silver.withValues(alpha: 0.3),
+                  borderRadius: BorderRadius.circular(16),
+                  border: Border.all(
+                    color: isDark ? Colors.grey.shade600 : OsmeaColors.silver,
+                    width: 1,
+                  ),
+                ),
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Text(
+                      entry.key,
+                      style: TextStyle(
+                        fontSize: 12,
+                        fontWeight: FontWeight.w600,
+                        color:
+                            isDark ? Colors.grey.shade300 : OsmeaColors.pewter,
+                      ),
+                    ),
+                    const SizedBox(width: 4),
+                    Text(
+                      entry.value,
+                      style: TextStyle(
+                        fontSize: 12,
+                        color: isDark ? Colors.white : OsmeaColors.nordicBlue,
+                      ),
+                    ),
+                  ],
+                ),
+              );
+            }).toList(),
+          ),
+        ],
+      ],
+    );
+  }
+}

--- a/projects/storybook/lib/components/snackbar_storybook/sections/sample_content_section.dart
+++ b/projects/storybook/lib/components/snackbar_storybook/sections/sample_content_section.dart
@@ -1,0 +1,188 @@
+import 'package:flutter/material.dart';
+import 'package:osmea_components/osmea_components.dart';
+
+/// 💬 **Sample Content Section**
+///
+/// Demonstrates snackbar usage with sample content and real-world scenarios
+/// Updated to work with device frame context
+
+class SnackbarSampleContentSection extends StatelessWidget {
+  final SnackbarType type;
+  final SnackbarPosition position;
+  final SnackbarAnimation animation;
+  final SnackbarStyle style;
+  final Duration duration;
+  final bool isDark;
+  final double spacing;
+  final Function(SnackbarType, String, {String? title, String? actionLabel, Duration? duration}) onShowSnackbar;
+
+  const SnackbarSampleContentSection({
+    Key? key,
+    required this.type,
+    required this.position,
+    required this.animation,
+    required this.style,
+    required this.duration,
+    this.isDark = false,
+    this.spacing = 16.0,
+    required this.onShowSnackbar,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          'Sample Content Examples',
+          style: TextStyle(
+            fontSize: 18,
+            fontWeight: FontWeight.bold,
+            color: isDark ? Colors.white : OsmeaColors.nordicBlue,
+          ),
+        ),
+        const SizedBox(height: 16),
+
+        // Sample Scenarios
+        Wrap(
+          spacing: spacing,
+          runSpacing: spacing,
+          children: [
+            _buildSampleCard(
+              context,
+              'Form Submission',
+              'Success confirmation for form submissions',
+              Icons.check_circle,
+              Colors.green,
+              () => onShowSnackbar(SnackbarType.success, 'Form submitted successfully!'),
+            ),
+            _buildSampleCard(
+              context,
+              'Error Handling',
+              'Error messages with actionable solutions',
+              Icons.error,
+              Colors.red,
+              () => onShowSnackbar(SnackbarType.error, 'Something went wrong. Please try again.'),
+            ),
+            _buildSampleCard(
+              context,
+              'Warning Alert',
+              'Warning messages for important considerations',
+              Icons.warning,
+              Colors.orange,
+              () => onShowSnackbar(SnackbarType.warning, 'This action cannot be undone.'),
+            ),
+            _buildSampleCard(
+              context,
+              'Info Notification',
+              'Informational messages and updates',
+              Icons.info,
+              Colors.blue,
+              () => onShowSnackbar(SnackbarType.info, 'New features are available.'),
+            ),
+            _buildSampleCard(
+              context,
+              'With Action',
+              'Snackbars with action buttons',
+              Icons.undo,
+              Colors.purple,
+              () => onShowSnackbar(
+                SnackbarType.info, 
+                'Item deleted from cart',
+                actionLabel: 'Undo',
+              ),
+            ),
+            _buildSampleCard(
+              context,
+              'Progress Update',
+              'Snackbars with progress indicators',
+              Icons.upload,
+              Colors.teal,
+              () => onShowSnackbar(
+                SnackbarType.info, 
+                'Uploading file...',
+                duration: const Duration(seconds: 10),
+              ),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+
+  Widget _buildSampleCard(
+    BuildContext context,
+    String title,
+    String description,
+    IconData icon,
+    Color color,
+    VoidCallback onPressed,
+  ) {
+    final backgroundColor = isDark ? Colors.grey.shade800 : Colors.white;
+    final borderColor = isDark ? Colors.grey.shade700 : OsmeaColors.silver;
+    final textColor = isDark ? Colors.grey.shade300 : OsmeaColors.pewter;
+
+    return Container(
+      width: 200,
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: backgroundColor,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: borderColor, width: 1),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.05),
+            blurRadius: 8,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(icon, color: color, size: 20),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  title,
+                  style: TextStyle(
+                    fontSize: 14,
+                    fontWeight: FontWeight.bold,
+                    color: isDark ? Colors.white : OsmeaColors.nordicBlue,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          Text(
+            description,
+            style: TextStyle(
+              fontSize: 12,
+              color: textColor,
+              height: 1.3,
+            ),
+          ),
+          const SizedBox(height: 12),
+          SizedBox(
+            width: double.infinity,
+            child: ElevatedButton(
+              onPressed: onPressed,
+              style: ElevatedButton.styleFrom(
+                backgroundColor: color,
+                foregroundColor: Colors.white,
+                padding: const EdgeInsets.symmetric(vertical: 8),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(8),
+                ),
+              ),
+              child: const Text('Show Snackbar'),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/projects/storybook/lib/components/snackbar_storybook/showcase/snackbar_showcase_widget.dart
+++ b/projects/storybook/lib/components/snackbar_storybook/showcase/snackbar_showcase_widget.dart
@@ -1,0 +1,715 @@
+import 'dart:async';
+import 'package:flutter/material.dart';
+import 'package:osmea_components/osmea_components.dart';
+
+/// Local snackbar data for device frame showcase
+class _DeviceFrameSnackbar {
+  final String id;
+  final String? title;
+  final String message;
+  final SnackbarType type;
+  final SnackbarPosition position;
+  final SnackbarAnimation animation;
+  final SnackbarVisualStyle visualStyle;
+  final Duration duration;
+  final DateTime createdAt;
+  final String? actionLabel;
+  final VoidCallback? onAction;
+  double progress; // Progress countdown from 1.0 to 0.0 (full to empty)
+
+  _DeviceFrameSnackbar({
+    required this.id,
+    this.title,
+    required this.message,
+    required this.type,
+    required this.position,
+    required this.animation,
+    required this.visualStyle,
+    required this.duration,
+    DateTime? createdAt,
+    this.actionLabel,
+    this.onAction,
+    this.progress = 0.0,
+  }) : createdAt = createdAt ?? DateTime.now();
+}
+
+/// 💬 **Snackbar Showcase Widget**
+/// 
+/// Simple showcase with device frame positioned snackbars
+/// No performance-heavy timers or complex systems
+class UnifiedSnackbarShowcaseWidget extends StatefulWidget {
+  // Snackbar Properties
+  final SnackbarType type;
+  final SnackbarPosition position;
+  final SnackbarAnimation animation;
+  final SnackbarVisualStyle visualStyle;
+  
+  // Content
+  final String message;
+  final String? title;
+  final String? actionLabel;
+  
+  // Duration and Progress
+  final Duration duration;
+  final double? progress;
+  
+  // Layout Options
+  final double spacing;
+
+  const UnifiedSnackbarShowcaseWidget({
+    super.key,
+    required this.type,
+    required this.position,
+    required this.animation,
+    required this.visualStyle,
+    required this.message,
+    this.title,
+    this.actionLabel,
+    required this.duration,
+    this.progress,
+    required this.spacing,
+  });
+
+  @override
+  State<UnifiedSnackbarShowcaseWidget> createState() => _UnifiedSnackbarShowcaseWidgetState();
+}
+
+class _UnifiedSnackbarShowcaseWidgetState extends State<UnifiedSnackbarShowcaseWidget> {
+  // Maximum number of snackbars allowed on screen (matching main component)
+  static const int _maxSnackbars = 3;
+  
+  int _demoCounter = 0;
+  final List<_DeviceFrameSnackbar> _deviceFrameSnackbars = [];
+  final Map<String, Timer> _progressTimers = {};
+
+  @override
+  void dispose() {
+    for (final timer in _progressTimers.values) {
+      timer.cancel();
+    }
+    _progressTimers.clear();
+    super.dispose();
+  }
+  
+  /// Adds a snackbar with limit enforcement (matching main component behavior)
+  void _addSnackbarWithLimit(_DeviceFrameSnackbar snackbar) {
+    // If we have reached the limit, remove the oldest snackbars
+    if (_deviceFrameSnackbars.length >= _maxSnackbars) {
+      final toRemove = _deviceFrameSnackbars.length - _maxSnackbars + 1;
+      for (int i = 0; i < toRemove; i++) {
+        final oldSnackbar = _deviceFrameSnackbars.removeAt(0);
+        // Cancel its timer if it exists
+        final timer = _progressTimers.remove(oldSnackbar.id);
+        timer?.cancel();
+      }
+    }
+    
+    // Add the new snackbar
+    _deviceFrameSnackbars.add(snackbar);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.grey[50],
+      body: Stack(
+        children: [
+          SafeArea(
+            child: SingleChildScrollView(
+              padding: const EdgeInsets.all(20),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  // Title
+                  const Text(
+                    '💬 Snackbar Showcase',
+                    style: TextStyle(
+                      fontSize: 24,
+                      fontWeight: FontWeight.bold,
+                      color: Colors.black87,
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  // Description
+                  Text(
+                    'Interactive snackbar demonstrations within device frame',
+                    style: TextStyle(
+                      fontSize: 16,
+                      color: Colors.grey[600],
+                    ),
+                  ),
+                  const SizedBox(height: 24),
+                  
+                  // Main demonstration area
+                  _buildDemoArea(context),
+                  
+                  const SizedBox(height: 32),
+                  
+                  // Configuration Panel
+                  _buildConfigurationInfo(context),
+                  
+                  // Add bottom padding for snackbars
+                  const SizedBox(height: 200),
+                ],
+              ),
+            ),
+          ),
+          
+          // Device frame snackbars overlay
+          ..._buildDeviceFrameSnackbars(),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildDemoArea(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      height: 300,
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: Colors.grey[300]!),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withAlpha(25),
+            blurRadius: 10,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(
+              Icons.message_rounded,
+              size: 48,
+              color: Colors.grey[400],
+            ),
+            const SizedBox(height: 12),
+            Text(
+              'Snackbar Demo Area',
+              style: TextStyle(
+                fontSize: 16,
+                color: Colors.grey[600],
+              ),
+            ),
+            const SizedBox(height: 4),
+            Text(
+              'Click buttons to show snackbars within device frame',
+              style: TextStyle(
+                fontSize: 12,
+                color: Colors.grey[500],
+              ),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 24),
+            
+            // Demo buttons
+            ElevatedButton(
+              onPressed: _showDeviceFrameSnackbar,
+              child: const Text('Show Snackbar'),
+            ),
+            const SizedBox(height: 12),
+            ElevatedButton(
+              onPressed: _showMultipleDeviceFrameSnackbars,
+              child: const Text('Show Multiple Snackbars'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _showDeviceFrameSnackbar() {
+    try {
+      final snackbar = _DeviceFrameSnackbar(
+        id: DateTime.now().millisecondsSinceEpoch.toString(),
+        title: widget.title,
+        message: widget.message,
+        type: widget.type,
+        position: widget.position,
+        animation: widget.animation,
+        visualStyle: widget.visualStyle,
+        duration: widget.duration,
+        actionLabel: widget.actionLabel,
+        onAction: widget.actionLabel != null ? () {
+          _demoCounter++;
+          _showDeviceFrameActionSnackbar('Demo action $_demoCounter executed!');
+        } : null,
+      );
+      
+      if (mounted) {
+        setState(() {
+          _addSnackbarWithLimit(snackbar);
+        });
+        
+        _scheduleSnackbarRemoval(snackbar);
+      }
+    } catch (e) {
+      debugPrint('Error showing snackbar: $e');
+    }
+  }
+  
+  void _showDeviceFrameActionSnackbar(String message) {
+    final snackbar = _DeviceFrameSnackbar(
+      id: '${DateTime.now().millisecondsSinceEpoch}_action',
+      message: message,
+      type: SnackbarType.success,
+      position: widget.position,
+      animation: widget.animation,
+      visualStyle: widget.visualStyle,
+      duration: const Duration(seconds: 2),
+    );
+    
+    setState(() {
+      _addSnackbarWithLimit(snackbar);
+    });
+    
+    _scheduleSnackbarRemoval(snackbar);
+  }
+  
+  void _showMultipleDeviceFrameSnackbars() {
+    final types = [SnackbarType.success, SnackbarType.info, SnackbarType.warning];
+    
+    for (int i = 0; i < 3; i++) {
+      Future.delayed(Duration(milliseconds: i * 600), () {
+        if (mounted) {
+          final snackbar = _DeviceFrameSnackbar(
+            id: '${DateTime.now().millisecondsSinceEpoch}$i',
+            title: widget.title,
+            message: 'This is snackbar ${i + 1} of 3',
+            type: types[i],
+            position: widget.position,
+            animation: widget.animation,
+            visualStyle: widget.visualStyle,
+            duration: widget.duration,
+            actionLabel: widget.actionLabel,
+            onAction: widget.actionLabel != null ? () {
+              _demoCounter++;
+              _showDeviceFrameActionSnackbar('Multiple demo action $_demoCounter executed!');
+            } : null,
+          );
+          
+          setState(() {
+            _addSnackbarWithLimit(snackbar);
+          });
+          
+          _scheduleSnackbarRemoval(snackbar);
+        }
+      });
+    }
+  }
+  
+
+  
+  void _scheduleSnackbarRemoval(_DeviceFrameSnackbar snackbar) {
+    const updateInterval = Duration(milliseconds: 50); // Update every 50ms for smooth animation
+    final totalDuration = snackbar.duration.inMilliseconds;
+    var elapsed = 0;
+
+    _progressTimers[snackbar.id] = Timer.periodic(updateInterval, (timer) {
+      if (!mounted) {
+        timer.cancel();
+        _progressTimers.remove(snackbar.id);
+        return;
+      }
+
+      elapsed += updateInterval.inMilliseconds;
+      final progress = elapsed / totalDuration; // Start at 0.0, increase to 1.0
+
+      if (progress >= 1.0) {
+        // Time's up - remove snackbar
+        timer.cancel();
+        _progressTimers.remove(snackbar.id);
+        if (mounted) {
+          setState(() {
+            _deviceFrameSnackbars.removeWhere((s) => s.id == snackbar.id);
+          });
+        }
+      } else {
+        // Update progress countdown
+        final index = _deviceFrameSnackbars.indexWhere((s) => s.id == snackbar.id);
+        if (index != -1) {
+          final updatedSnackbar = _DeviceFrameSnackbar(
+            id: snackbar.id,
+            title: snackbar.title,
+            message: snackbar.message,
+            type: snackbar.type,
+            position: snackbar.position,
+            animation: snackbar.animation,
+            visualStyle: snackbar.visualStyle,
+            duration: snackbar.duration,
+            createdAt: snackbar.createdAt,
+            actionLabel: snackbar.actionLabel,
+            onAction: snackbar.onAction,
+            progress: progress.clamp(0.0, 1.0),
+          );
+          
+          _deviceFrameSnackbars[index] = updatedSnackbar;
+          if (mounted) {
+            setState(() {});
+          }
+        }
+      }
+    });
+  }
+
+  List<Widget> _buildDeviceFrameSnackbars() {
+    if (_deviceFrameSnackbars.isEmpty) return [];
+
+    // Group by position
+    final Map<SnackbarPosition, List<_DeviceFrameSnackbar>> grouped = {
+      SnackbarPosition.top: [],
+      SnackbarPosition.center: [],
+      SnackbarPosition.bottom: [],
+    };
+    
+    for (final snackbar in _deviceFrameSnackbars) {
+      grouped[snackbar.position]!.add(snackbar);
+    }
+
+    final List<Widget> overlays = [];
+    
+    // Build positioned groups
+    for (final position in SnackbarPosition.values) {
+      if (grouped[position]!.isNotEmpty) {
+        overlays.add(_buildPositionedSnackbarGroup(context, position, grouped[position]!));
+      }
+    }
+    
+    return overlays;
+  }
+  
+  Widget _buildPositionedSnackbarGroup(BuildContext context, SnackbarPosition position, List<_DeviceFrameSnackbar> snackbars) {
+    if (snackbars.isEmpty) return const SizedBox.shrink();
+    
+    // Sort by creation time and apply proper display order like original
+    snackbars.sort((a, b) => a.createdAt.compareTo(b.createdAt));
+    final List<_DeviceFrameSnackbar> displaySnackbars =
+        position == SnackbarPosition.bottom
+            ? snackbars.reversed.toList()
+            : snackbars;
+
+    Alignment alignment;
+    EdgeInsets padding;
+
+    switch (position) {
+      case SnackbarPosition.top:
+        alignment = Alignment.topCenter;
+        padding = const EdgeInsets.only(top: 24, left: 16, right: 16);
+        break;
+      case SnackbarPosition.center:
+        alignment = Alignment.center;
+        padding = const EdgeInsets.symmetric(horizontal: 16);
+        break;
+      case SnackbarPosition.bottom:
+        alignment = Alignment.bottomCenter;
+        padding = const EdgeInsets.only(bottom: 12, left: 16, right: 16); // Match main component
+        break;
+    }
+
+    return Align(
+      alignment: alignment,
+      child: SafeArea(
+        bottom: position == SnackbarPosition.bottom,
+        top: position == SnackbarPosition.top,
+        child: Padding(
+          padding: padding,
+          child: ClipRect(
+            child: Stack(
+            children: displaySnackbars.asMap().entries.map((entry) {
+              final index = entry.key;
+              final snackbar = entry.value;
+              
+              // Different positioning logic for different positions (matching main component)
+              Widget positionedSnackbar;
+              switch (position) {
+                case SnackbarPosition.top:
+                  positionedSnackbar = Positioned(
+                    top: index * 8.0,
+                    left: 0,
+                    right: 0,
+                    child: Transform.translate(
+                      offset: Offset(0, index * 2.0),
+                      child: _buildSnackbarWidget(snackbar),
+                    ),
+                  );
+                  break;
+                case SnackbarPosition.center:
+                  // For center position, position relative to center point
+                  // First snackbar at center, subsequent ones offset upward
+                  positionedSnackbar = Positioned(
+                    top: 0,
+                    bottom: 0,
+                    left: 0,
+                    right: 0,
+                    child: Align(
+                      alignment: Alignment.center,
+                      child: Transform.translate(
+                        offset: Offset(0, -index * 10.0), // Stack upward from center
+                        child: _buildSnackbarWidget(snackbar),
+                      ),
+                    ),
+                  );
+                  break;
+                case SnackbarPosition.bottom:
+                  positionedSnackbar = Positioned(
+                    bottom: index * 8.0,
+                    left: 0,
+                    right: 0,
+                    child: Transform.translate(
+                      offset: Offset(0, -index * 2.0),
+                      child: _buildSnackbarWidget(snackbar),
+                    ),
+                  );
+                  break;
+              }
+              
+              return positionedSnackbar;
+            }).toList(),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+  
+  Widget _buildSnackbarWidget(_DeviceFrameSnackbar snackbar) {
+    return Container(
+      constraints: const BoxConstraints(maxWidth: 600),
+      child: _buildCustomSnackbar(snackbar),
+    );
+  }
+  
+  Widget _buildCustomSnackbar(_DeviceFrameSnackbar snackbar) {
+    return Container(
+      margin: const EdgeInsets.symmetric(horizontal: 16),
+      decoration: BoxDecoration(
+        color: _getSnackbarColor(snackbar.type),
+        borderRadius: BorderRadius.circular(12),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.2),
+            blurRadius: 8,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          // Main content
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+            child: Row(
+              children: [
+                Icon(
+                  _getSnackbarIcon(snackbar.type),
+                  color: Colors.white,
+                  size: 20,
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      if (snackbar.title != null) ...[
+                        Text(
+                          snackbar.title!,
+                          style: const TextStyle(
+                            color: Colors.white,
+                            fontWeight: FontWeight.bold,
+                            fontSize: 14,
+                          ),
+                        ),
+                        const SizedBox(height: 2),
+                      ],
+                      Text(
+                        snackbar.message,
+                        style: const TextStyle(
+                          color: Colors.white,
+                          fontSize: 14,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                if (snackbar.actionLabel != null) ...[
+                  GestureDetector(
+                    onTap: () {
+                      if (mounted) {
+                        _progressTimers[snackbar.id]?.cancel();
+                        _progressTimers.remove(snackbar.id);
+                        setState(() {
+                          _deviceFrameSnackbars.removeWhere((s) => s.id == snackbar.id);
+                        });
+                        snackbar.onAction?.call();
+                      }
+                    },
+                    child: Container(
+                      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                      child: Text(
+                        snackbar.actionLabel!,
+                        style: const TextStyle(
+                          color: Colors.white,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
+                GestureDetector(
+                  onTap: () {
+                    if (mounted) {
+                      _progressTimers[snackbar.id]?.cancel();
+                      _progressTimers.remove(snackbar.id);
+                      setState(() {
+                        _deviceFrameSnackbars.removeWhere((s) => s.id == snackbar.id);
+                      });
+                    }
+                  },
+                  child: Container(
+                    padding: const EdgeInsets.all(4),
+                    child: const Icon(Icons.close, color: Colors.white, size: 18),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          
+          // Progress bar (countdown timer like in the image)
+          Container(
+            height: 4,
+            margin: EdgeInsets.zero,
+            decoration: const BoxDecoration(
+              color: Colors.transparent,
+            ),
+            child: LinearProgressIndicator(
+              value: snackbar.progress.clamp(0.0, 1.0),
+              backgroundColor: Colors.transparent,
+              valueColor: AlwaysStoppedAnimation<Color>(
+                _getProgressColor(snackbar.type),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Color _getSnackbarColor(SnackbarType type) {
+    switch (type) {
+      case SnackbarType.success:
+        return Colors.green[600]!;
+      case SnackbarType.error:
+        return Colors.red[600]!;
+      case SnackbarType.warning:
+        return Colors.orange[600]!;
+      case SnackbarType.info:
+        return Colors.blue[600]!;
+    }
+  }
+  
+  Color _getProgressColor(SnackbarType type) {
+    switch (type) {
+      case SnackbarType.success:
+        return Colors.green[300]!; // Lighter green for visibility
+      case SnackbarType.error:
+        return Colors.red[300]!; // Lighter red for visibility
+      case SnackbarType.warning:
+        return Colors.orange[300]!; // Lighter orange for visibility
+      case SnackbarType.info:
+        return Colors.blue[300]!; // Lighter blue for visibility
+    }
+  }
+  
+  IconData _getSnackbarIcon(SnackbarType type) {
+    switch (type) {
+      case SnackbarType.success:
+        return Icons.check_circle_outline;
+      case SnackbarType.error:
+        return Icons.error_outline;
+      case SnackbarType.warning:
+        return Icons.warning_amber_outlined;
+      case SnackbarType.info:
+        return Icons.info_outline;
+    }
+  }
+
+
+
+  Widget _buildConfigurationInfo(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: Colors.grey[50],
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: Colors.grey[300]!),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Current Configuration',
+            style: Theme.of(context).textTheme.titleMedium?.copyWith(
+              fontWeight: FontWeight.bold,
+              color: Colors.black87,
+            ),
+          ),
+          const SizedBox(height: 12),
+          Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            children: [
+              _buildConfigChip('Type', widget.type.toString().split('.').last),
+              _buildConfigChip('Position', widget.position.toString().split('.').last),
+              _buildConfigChip('Animation', widget.animation.toString().split('.').last),
+              _buildConfigChip('Visual Style', widget.visualStyle.toString().split('.').last),
+              _buildConfigChip('Message', widget.message.length > 20 ? '${widget.message.substring(0, 20)}...' : widget.message),
+              if (widget.title != null) _buildConfigChip('Title', widget.title!),
+              _buildConfigChip('Duration', '${widget.duration.inSeconds}s'),
+              if (widget.actionLabel != null) 
+                _buildConfigChip('Action Label', widget.actionLabel!),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildConfigChip(String label, String value) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: Colors.grey[300]!),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(
+            '$label: ',
+            style: const TextStyle(
+              fontSize: 12,
+              fontWeight: FontWeight.w500,
+              color: Colors.black87,
+            ),
+          ),
+          Text(
+            value,
+            style: const TextStyle(
+              fontSize: 12,
+              color: Colors.black54,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+

--- a/projects/storybook/lib/components/snackbar_storybook/showcase/unified_snackbar_showcase.dart
+++ b/projects/storybook/lib/components/snackbar_storybook/showcase/unified_snackbar_showcase.dart
@@ -1,0 +1,77 @@
+import 'package:osmea_components/osmea_components.dart';
+import 'package:storybook_flutter/storybook_flutter.dart';
+
+// Import the main showcase widget and utils
+import 'snackbar_showcase_widget.dart';
+import '../utils/knobs_config.dart';
+
+/// 💬 **Unified Snackbar Showcase - Modular Structure**
+/// 
+/// Single story that shows all snackbar variations in one place
+/// All knobs control the snackbar simultaneously for easy testing
+
+List<Story> getUnifiedSnackbarShowcase() {
+  return [
+    Story(
+      name: 'Snackbars',
+      builder: (context) {
+        // Get combined type configuration
+        final combinedConfig = SnackbarKnobsConfig.getCombinedTypeKnob(context);
+        
+        return UnifiedSnackbarShowcaseWidget(
+          // Type Controls - combined type/message/title
+          type: combinedConfig.type,
+        
+          // Position Controls (top, center, and bottom)
+          position: context.knobs.options(
+            label: 'Position',
+            initial: SnackbarPosition.bottom,
+            options: const [
+              Option(label: 'Top', value: SnackbarPosition.top),
+              Option(label: 'Center', value: SnackbarPosition.center),
+              Option(label: 'Bottom', value: SnackbarPosition.bottom),
+            ],
+          ),
+          
+          // Animation Controls
+          animation: context.knobs.options(
+            label: 'Animation',
+            initial: SnackbarAnimation.slide,
+            options: const [
+              Option(label: 'Fade', value: SnackbarAnimation.fade),
+              Option(label: 'Slide', value: SnackbarAnimation.slide),
+              Option(label: 'Scale', value: SnackbarAnimation.scale),
+            ],
+          ),
+          
+          // Use default visual style (classic)
+          visualStyle: SnackbarVisualStyle.classic,
+          
+          // Content Controls - from combined configuration
+          message: combinedConfig.message,
+          title: combinedConfig.title,
+        
+          actionLabel: SnackbarKnobsConfig.getActionLabelKnob(context),
+        
+          // Duration Controls
+          duration: context.knobs.options(
+            label: 'Duration',
+            initial: const Duration(seconds: 4),
+            options: const [
+              Option(label: '2 seconds', value: Duration(seconds: 2)),
+              Option(label: '4 seconds', value: Duration(seconds: 4)),
+              Option(label: '6 seconds', value: Duration(seconds: 6)),
+              Option(label: '10 seconds', value: Duration(seconds: 10)),
+            ],
+          ),
+          
+          // Progress is now automatic countdown - no manual control needed
+          progress: null,
+        
+          // Layout Options
+          spacing: 16.0,
+        );
+      },
+    ),
+  ];
+}

--- a/projects/storybook/lib/components/snackbar_storybook/snackbars.dart
+++ b/projects/storybook/lib/components/snackbar_storybook/snackbars.dart
@@ -1,0 +1,20 @@
+import 'package:storybook_flutter/storybook_flutter.dart';
+
+// Import the unified snackbar showcase
+import 'showcase/unified_snackbar_showcase.dart';
+
+/// 💬 **Snackbar Component Stories - Modular Structure**
+/// 
+/// Main aggregation function for all snackbar stories following the modular template.
+/// This file serves as the entry point for all snackbar-related showcases.
+
+List<Story> getAllSnackbarStories() {
+  return [
+    // Unified Snackbar Showcase - All Variants
+    ...getUnifiedSnackbarShowcase(),
+    
+    // Note: Individual snackbar stories are replaced by unified showcase
+    // This new approach shows all snackbar variations in one place
+    // with all knobs affecting every snackbar simultaneously
+  ];
+}

--- a/projects/storybook/lib/components/snackbar_storybook/utils/knobs_config.dart
+++ b/projects/storybook/lib/components/snackbar_storybook/utils/knobs_config.dart
@@ -1,0 +1,186 @@
+import 'package:flutter/material.dart';
+import 'package:osmea_components/osmea_components.dart';
+import 'package:storybook_flutter/storybook_flutter.dart';
+
+/// 💬 **Snackbar Knobs Configuration**
+/// 
+/// Configuration and helper functions for snackbar storybook knobs
+
+class SnackbarKnobsConfig {
+  /// Combined type, message, and title configuration
+  static const List<Option<SnackbarTypeConfig>> combinedTypeOptions = [
+    Option(
+      label: 'Success', 
+      value: SnackbarTypeConfig(
+        type: SnackbarType.success,
+        title: 'Success',
+        message: 'Operation completed successfully!',
+      ),
+    ),
+    Option(
+      label: 'Error', 
+      value: SnackbarTypeConfig(
+        type: SnackbarType.error,
+        title: 'Error',
+        message: 'Something went wrong. Please try again.',
+      ),
+    ),
+    Option(
+      label: 'Warning', 
+      value: SnackbarTypeConfig(
+        type: SnackbarType.warning,
+        title: 'Warning',
+        message: 'Please check your input before proceeding.',
+      ),
+    ),
+    Option(
+      label: 'Info', 
+      value: SnackbarTypeConfig(
+        type: SnackbarType.info,
+        title: 'Information',
+        message: 'Here\'s some helpful information.',
+      ),
+    ),
+  ];
+
+  /// Position options for Storybook (top, center, and bottom)
+  static const List<Option<SnackbarPosition>> positionOptions = [
+    Option(label: 'Top', value: SnackbarPosition.top),
+    Option(label: 'Center', value: SnackbarPosition.center),
+    Option(label: 'Bottom', value: SnackbarPosition.bottom),
+  ];
+
+  /// Animation options for Storybook
+  static const List<Option<SnackbarAnimation>> animationOptions = [
+    Option(label: 'Fade', value: SnackbarAnimation.fade),
+    Option(label: 'Slide', value: SnackbarAnimation.slide),
+    Option(label: 'Scale', value: SnackbarAnimation.scale),
+  ];
+
+  /// Visual Style options for Storybook (using actual rendering styles)
+  static const List<Option<SnackbarVisualStyle>> visualStyleOptions = [
+    Option(label: 'Classic', value: SnackbarVisualStyle.classic),
+    Option(label: 'Modern', value: SnackbarVisualStyle.modern),
+    Option(label: 'Glass', value: SnackbarVisualStyle.glass),
+    Option(label: 'Circle', value: SnackbarVisualStyle.circle),
+    Option(label: 'Patterned', value: SnackbarVisualStyle.patterned),
+    Option(label: 'Glow', value: SnackbarVisualStyle.glow),
+  ];
+
+
+
+
+
+  /// Action label options for Storybook
+  static const List<Option<String>> actionLabelOptions = [
+    Option(label: 'Undo', value: 'Undo'),
+    Option(label: 'Retry', value: 'Retry'),
+    Option(label: 'Dismiss', value: 'Dismiss'),
+    Option(label: 'View', value: 'View'),
+    Option(label: 'Settings', value: 'Settings'),
+    Option(label: 'Learn More', value: 'Learn More'),
+  ];
+
+  /// Duration options for Storybook
+  static const List<Option<Duration>> durationOptions = [
+    Option(label: '2 seconds', value: Duration(seconds: 2)),
+    Option(label: '4 seconds', value: Duration(seconds: 4)),
+    Option(label: '6 seconds', value: Duration(seconds: 6)),
+    Option(label: '10 seconds', value: Duration(seconds: 10)),
+  ];
+
+
+
+  /// Helper to get combined type configuration knob
+  static SnackbarTypeConfig getCombinedTypeKnob(BuildContext context) {
+    return context.knobs.options(
+      label: '🍿 Snackbar Type (Combined)',
+      initial: const SnackbarTypeConfig(
+        type: SnackbarType.success,
+        title: 'Success',
+        message: 'Operation completed successfully!',
+      ),
+      options: combinedTypeOptions,
+    );
+  }
+
+
+
+  /// Helper to get position knob
+  static SnackbarPosition getPositionKnob(BuildContext context) {
+    return context.knobs.options(
+      label: '📍 Position',
+      initial: SnackbarPosition.bottom,
+      options: positionOptions,
+    );
+  }
+
+  /// Helper to get animation knob
+  static SnackbarAnimation getAnimationKnob(BuildContext context) {
+    return context.knobs.options(
+      label: '🎬 Animation',
+      initial: SnackbarAnimation.slide,
+      options: animationOptions,
+    );
+  }
+
+  /// Helper to get visual style knob
+  static SnackbarVisualStyle getVisualStyleKnob(BuildContext context) {
+    return context.knobs.options(
+      label: '🎨 Visual Style',
+      initial: SnackbarVisualStyle.classic,
+      options: visualStyleOptions,
+    );
+  }
+
+
+
+
+
+  /// Helper to get action label knob
+  static String getActionLabelKnob(BuildContext context) {
+    return context.knobs.options(
+      label: '🔘 Action Label',
+      initial: 'Undo',
+      options: actionLabelOptions,
+    );
+  }
+
+  /// Helper to get duration knob
+  static Duration getDurationKnob(BuildContext context) {
+    return context.knobs.options(
+      label: '⏱️ Duration',
+      initial: const Duration(seconds: 4),
+      options: durationOptions,
+    );
+  }
+
+
+
+
+}
+
+/// Configuration class that combines type, title, and message
+class SnackbarTypeConfig {
+  final SnackbarType type;
+  final String title;
+  final String message;
+
+  const SnackbarTypeConfig({
+    required this.type,
+    required this.title,
+    required this.message,
+  });
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is SnackbarTypeConfig &&
+        other.type == type &&
+        other.title == title &&
+        other.message == message;
+  }
+
+  @override
+  int get hashCode => type.hashCode ^ title.hashCode ^ message.hashCode;
+}

--- a/projects/storybook/lib/components/snackbar_storybook/utils/snackbar_builder.dart
+++ b/projects/storybook/lib/components/snackbar_storybook/utils/snackbar_builder.dart
@@ -1,0 +1,291 @@
+import 'package:flutter/material.dart';
+import 'package:osmea_components/osmea_components.dart';
+
+/// 💬 **Snackbar Builder Utility**
+/// 
+/// Helper utilities for snackbar construction and configuration
+/// Updated to work with device frame context
+
+class SnackbarBuilder {
+  /// Convert enum to string representation
+  static String enumToString(dynamic enumValue) {
+    return enumValue.toString().split('.').last;
+  }
+
+  /// Format enum names for display
+  static String formatEnumName(String enumName) {
+    // Convert camelCase to Title Case
+    return enumName
+        .replaceAllMapped(RegExp(r'([A-Z])'), (match) => ' ${match.group(1)}')
+        .trim()
+        .split(' ')
+        .map((word) => word[0].toUpperCase() + word.substring(1).toLowerCase())
+        .join(' ');
+  }
+
+  /// Build snackbar with common parameters (for device frame context)
+  static void showSnackbar({
+    required BuildContext context,
+    required SnackbarType type,
+    required SnackbarPosition position,
+    required SnackbarAnimation animation,
+    required SnackbarStyle style,
+    required String message,
+    String? title,
+    String? actionLabel,
+    Duration? duration,
+    VoidCallback? onAction,
+  }) {
+    // For device frame context, we use the custom snackbar system
+    // This ensures snackbars appear within the device frame boundaries
+    switch (type) {
+      case SnackbarType.success:
+        context.snackbarSuccess(
+          message,
+          title: title,
+          style: style,
+          position: position,
+          animation: animation,
+          duration: duration,
+          actionLabel: actionLabel,
+          onAction: onAction,
+        );
+        break;
+      case SnackbarType.error:
+        context.snackbarError(
+          message,
+          title: title,
+          style: style,
+          position: position,
+          animation: animation,
+          duration: duration,
+          actionLabel: actionLabel,
+          onAction: onAction,
+        );
+        break;
+      case SnackbarType.warning:
+        context.snackbarWarning(
+          message,
+          title: title,
+          style: style,
+          position: position,
+          animation: animation,
+          duration: duration,
+          actionLabel: actionLabel,
+          onAction: onAction,
+        );
+        break;
+      case SnackbarType.info:
+        context.snackbarInfo(
+          message,
+          title: title,
+          style: style,
+          position: position,
+          animation: animation,
+          duration: duration,
+          actionLabel: actionLabel,
+          onAction: onAction,
+        );
+        break;
+    }
+  }
+
+  /// Get sample messages for different snackbar types
+  static Map<SnackbarType, List<String>> getSampleMessages() {
+    return {
+      SnackbarType.success: [
+        'Operation completed successfully!',
+        'Changes saved successfully',
+        'Item added to cart',
+        'Profile updated successfully',
+      ],
+      SnackbarType.error: [
+        'Something went wrong. Please try again.',
+        'Connection failed. Check your internet.',
+        'Invalid input. Please check your data.',
+        'Operation failed. Please retry.',
+      ],
+      SnackbarType.warning: [
+        'Please check your input before proceeding.',
+        'This action cannot be undone.',
+        'You have unsaved changes.',
+        'Low battery. Please connect charger.',
+      ],
+      SnackbarType.info: [
+        'Here\'s some helpful information.',
+        'New features available.',
+        'System maintenance in 5 minutes.',
+        'Your session will expire soon.',
+      ],
+    };
+  }
+
+  /// Get sample action labels
+  static List<String> getSampleActionLabels() {
+    return [
+      'Undo',
+      'Retry',
+      'Dismiss',
+      'View',
+      'Settings',
+      'Learn More',
+    ];
+  }
+
+  /// Get sample durations
+  static List<Duration> getSampleDurations() {
+    return [
+      const Duration(seconds: 2),
+      const Duration(seconds: 4),
+      const Duration(seconds: 6),
+      const Duration(seconds: 8),
+      const Duration(seconds: 10),
+    ];
+  }
+
+  /// Create demonstration scenarios for snackbars
+  static List<Map<String, dynamic>> getSnackbarScenarios() {
+    return [
+      {
+        'title': 'Success Notification',
+        'description': 'Confirm successful operations',
+        'type': SnackbarType.success,
+        'message': 'Operation completed successfully!',
+        'actionLabel': 'View Details',
+      },
+      {
+        'title': 'Error Alert',
+        'description': 'Notify users of errors',
+        'type': SnackbarType.error,
+        'message': 'Something went wrong. Please try again.',
+        'actionLabel': 'Retry',
+      },
+      {
+        'title': 'Warning Message',
+        'description': 'Alert users about potential issues',
+        'type': SnackbarType.warning,
+        'message': 'This action cannot be undone.',
+        'actionLabel': 'Proceed',
+      },
+      {
+        'title': 'Info Notification',
+        'description': 'Provide helpful information',
+        'type': SnackbarType.info,
+        'message': 'New features are available.',
+        'actionLabel': 'Learn More',
+      },
+      {
+        'title': 'Progress Update',
+        'description': 'Show operation progress',
+        'type': SnackbarType.info,
+        'message': 'Uploading file...',
+        'progress': 0.75,
+      },
+    ];
+  }
+
+  /// Get color for snackbar type
+  static Color getTypeColor(SnackbarType type) {
+    switch (type) {
+      case SnackbarType.success:
+        return Colors.green;
+      case SnackbarType.error:
+        return Colors.red;
+      case SnackbarType.warning:
+        return Colors.orange;
+      case SnackbarType.info:
+        return Colors.blue;
+    }
+  }
+
+  /// Get icon for snackbar type
+  static IconData getTypeIcon(SnackbarType type) {
+    switch (type) {
+      case SnackbarType.success:
+        return Icons.check_circle_outline;
+      case SnackbarType.error:
+        return Icons.error_outline;
+      case SnackbarType.warning:
+        return Icons.warning_amber_outlined;
+      case SnackbarType.info:
+        return Icons.info_outline;
+    }
+  }
+
+  /// Create a custom snackbar widget for device frame context
+  static Widget createCustomSnackbar({
+    required SnackbarType type,
+    required String message,
+    String? title,
+    String? actionLabel,
+    VoidCallback? onAction,
+    VoidCallback? onClose,
+  }) {
+    return Material(
+      elevation: 6,
+      borderRadius: BorderRadius.circular(8),
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+        decoration: BoxDecoration(
+          color: getTypeColor(type),
+          borderRadius: BorderRadius.circular(8),
+        ),
+        child: Row(
+          children: [
+            Icon(
+              getTypeIcon(type),
+              color: Colors.white,
+              size: 20,
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  if (title != null) ...[
+                    Text(
+                      title,
+                      style: const TextStyle(
+                        color: Colors.white,
+                        fontWeight: FontWeight.bold,
+                        fontSize: 14,
+                      ),
+                    ),
+                    const SizedBox(height: 2),
+                  ],
+                  Text(
+                    message,
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontSize: 14,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            if (actionLabel != null) ...[
+              TextButton(
+                onPressed: onAction,
+                child: Text(
+                  actionLabel,
+                  style: const TextStyle(
+                    color: Colors.white,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+              ),
+            ],
+            if (onClose != null)
+              IconButton(
+                onPressed: onClose,
+                icon: const Icon(Icons.close, color: Colors.white, size: 18),
+                padding: EdgeInsets.zero,
+                constraints: const BoxConstraints(),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/projects/storybook/lib/components/snackbar_storybook/widgets/section_container_widget.dart
+++ b/projects/storybook/lib/components/snackbar_storybook/widgets/section_container_widget.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/material.dart';
+import 'package:osmea_components/osmea_components.dart';
+
+/// 💬 **Section Container Widget**
+///
+/// Reusable container for organizing snackbar showcases into sections
+
+class SnackbarSectionContainerWidget extends StatelessWidget {
+  final String title;
+  final bool showTitle;
+  final double spacing;
+  final List<Widget> children;
+  final bool isDark;
+  final CrossAxisAlignment? crossAxisAlignment;
+  final MainAxisAlignment? mainAxisAlignment;
+  final bool wrapContent;
+
+  const SnackbarSectionContainerWidget({
+    Key? key,
+    required this.title,
+    this.showTitle = true,
+    this.spacing = 16.0,
+    required this.children,
+    this.isDark = false,
+    this.crossAxisAlignment,
+    this.mainAxisAlignment,
+    this.wrapContent = true,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final titleColor = isDark ? Colors.white : OsmeaColors.nordicBlue;
+    final backgroundColor = isDark ? Colors.grey.shade800 : Colors.white;
+    final borderColor = isDark ? Colors.grey.shade700 : OsmeaColors.silver;
+
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(20),
+      decoration: BoxDecoration(
+        color: backgroundColor,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: borderColor, width: 1),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.05),
+            blurRadius: 8,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: Column(
+        crossAxisAlignment: crossAxisAlignment ?? CrossAxisAlignment.start,
+        mainAxisAlignment: mainAxisAlignment ?? MainAxisAlignment.start,
+        children: [
+          if (showTitle) ...[
+            Text(
+              title,
+              style: TextStyle(
+                fontSize: 18,
+                fontWeight: FontWeight.bold,
+                color: titleColor,
+              ),
+            ),
+            SizedBox(height: spacing),
+          ],
+          if (wrapContent)
+            Wrap(
+              spacing: spacing,
+              runSpacing: spacing,
+              children: children,
+            )
+          else
+            Column(
+              crossAxisAlignment:
+                  crossAxisAlignment ?? CrossAxisAlignment.start,
+              mainAxisAlignment: mainAxisAlignment ?? MainAxisAlignment.start,
+              children: children
+                  .map((child) => Padding(
+                        padding: EdgeInsets.only(bottom: spacing),
+                        child: child,
+                      ))
+                  .toList(),
+            ),
+        ],
+      ),
+    );
+  }
+}

--- a/projects/storybook/lib/config/component_registry.dart
+++ b/projects/storybook/lib/config/component_registry.dart
@@ -27,6 +27,7 @@ import '../components/bottom_sheet_storybook/bottom_sheets.dart';
 import '../components/collapse_storybook/collapses.dart';
 import '../components/popup_storybook/popups.dart';
 import '../components/stepper_storybook/showcase/unified_stepper_showcase.dart';
+import '../components/snackbar_storybook/snackbars.dart';
 import '../components/dropdown_storybook/dropdowns.dart';
 
 
@@ -226,6 +227,14 @@ final List<ComponentInfo> allComponents = [
     color: Colors.teal,
     storyPath: StoryConfig.buildComponentStoryName('Searchbars'),
     getStories: getAllSearchbarStories,
+  ),
+  ComponentInfo(
+    name: 'Snackbars',
+    description: 'Temporary notifications and feedback messages with various styles',
+    icon: Icons.message_rounded,
+    color: Colors.orange,
+    storyPath: StoryConfig.buildComponentStoryName('Snackbars'),
+    getStories: getAllSnackbarStories,
   ),
   ComponentInfo(
     name: 'Steppers',


### PR DESCRIPTION
## 📋 PR Description

This PR implements a comprehensive Snackbar Storybook showcase that demonstrates all snackbar functionality within device frames. The implementation includes proper positioning for top, center, and bottom positions, progress bar animations with type-specific colors, and a maximum snackbar limit that matches the main component behavior.

Key features added:
- Device frame snackbar showcase with proper positioning logic
- Progress bar countdown animations that fill up over time
- Type-specific progress bar colors (lighter variants of snackbar colors)
- Maximum 3 snackbar limit with FIFO removal behavior

---

## ✅ Checklist

- [x] Code follows the project standards and guidelines.
- [ ] Relevant unit tests are written and all tests are passing.
- [x] Test coverage is adequate for the changes.
- [x] Any unnecessary files or debug statements have been removed.
- [x] Documentation is updated where necessary.
- [x] The PR has been reviewed by at least one team member before merging.

---

## 🛠 Steps to Test

1. Navigate to the Storybook application and open the Snackbar showcase
2. Test the "Show Snackbar" button to verify single snackbar display with progress animation
3. Test the "Show Multiple Snackbars" button to verify stacking behavior and 3-snackbar limit
4. Switch between Top, Center, and Bottom positions using the position knob to verify correct positioning
5. Test different snackbar types (Success, Info, Warning, Error) to verify type-specific progress bar colors
6. Verify that snackbars appear within device frame boundaries and stack properly
7. Confirm that progress bars fill up from empty to full before snackbars disappear

---

### 📷 Screenshots

| |
|---|
| <img width="544" height="1099" alt="Screenshot 2025-09-03 at 22 40 34" src="https://github.com/user-attachments/assets/84c53d4e-9390-4788-be57-e4d8dd8521b6" /> |
| <img width="527" height="1096" alt="Screenshot 2025-09-03 at 22 40 56" src="https://github.com/user-attachments/assets/9738cc80-5a0a-4982-bd36-12ff0ae59674" /> |
| <img width="536" height="1100" alt="Screenshot 2025-09-03 at 22 42 25" src="https://github.com/user-attachments/assets/65cf1c9a-da6d-44a8-87f5-7965d1742215" /> |
| <img width="529" height="1092" alt="Screenshot 2025-09-03 at 22 42 53" src="https://github.com/user-attachments/assets/97f167ae-3fca-44a9-bc64-6a7b0c3ac57c" /> |