### PR TITLE
OSMEA - Package - API -> Woocommerce Sign Up Module

### DIFF
--- a/packages/apis/lib/dio_config/dio_client/api_dio_client.dart
+++ b/packages/apis/lib/dio_config/dio_client/api_dio_client.dart
@@ -556,6 +556,7 @@ class ApiDioClient implements ApiBaseClient {
   static Future<WooAuthResult<UserSignUpData>> signUpUser({
     required String email,
     required String password,
+    required String authKey,
     required String firstName,
     required String lastName,
     String? phone,
@@ -571,6 +572,7 @@ class ApiDioClient implements ApiBaseClient {
       final result = await authManager.signUp(
         email: email,
         password: password,
+        authKey: authKey,
         firstName: firstName,
         lastName: lastName,
         phone: phone,

--- a/packages/apis/lib/network/remote/woocommerce/auth/api/api_woo_auth_service.dart
+++ b/packages/apis/lib/network/remote/woocommerce/auth/api/api_woo_auth_service.dart
@@ -39,7 +39,7 @@ abstract class ApiWooAuthService implements WooAuthService {
 
   /// 📝 User Sign Up
   /// Creates a new user account
-  @POST('/{brand_name}-auth-signup/v1/auth')
+  @POST('/?rest_route=/{brand_name}-auth-login/v1/users')
   @override
   Future<UserSignUpResponse> userSignUp(
     @Path('brand_name') String brandName,

--- a/packages/apis/lib/network/remote/woocommerce/auth/api/api_woo_auth_service.g.dart
+++ b/packages/apis/lib/network/remote/woocommerce/auth/api/api_woo_auth_service.g.dart
@@ -65,7 +65,7 @@ class _ApiWooAuthService implements ApiWooAuthService {
     )
             .compose(
               _dio.options,
-              '/${brandName}-auth-signup/v1/auth',
+              '/?rest_route=/${brandName}-auth-login/v1/users',
               queryParameters: queryParameters,
               data: _data,
             )

--- a/packages/apis/lib/network/remote/woocommerce/auth/freezed_model/request/delete_user_request.freezed.dart
+++ b/packages/apis/lib/network/remote/woocommerce/auth/freezed_model/request/delete_user_request.freezed.dart
@@ -29,12 +29,8 @@ mixin _$DeleteUserRequest {
   bool get deleteReviews => throw _privateConstructorUsedError;
   Map<String, dynamic>? get metadata => throw _privateConstructorUsedError;
 
-  /// Serializes this DeleteUserRequest to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of DeleteUserRequest
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $DeleteUserRequestCopyWith<DeleteUserRequest> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -63,8 +59,6 @@ class _$DeleteUserRequestCopyWithImpl<$Res, $Val extends DeleteUserRequest>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of DeleteUserRequest
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -123,8 +117,6 @@ class __$$DeleteUserRequestImplCopyWithImpl<$Res>
       $Res Function(_$DeleteUserRequestImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of DeleteUserRequest
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -213,14 +205,12 @@ class _$DeleteUserRequestImpl implements _DeleteUserRequest {
             const DeepCollectionEquality().equals(other._metadata, _metadata));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(runtimeType, userId, reason, deleteOrders,
       deleteReviews, const DeepCollectionEquality().hash(_metadata));
 
-  /// Create a copy of DeleteUserRequest
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$DeleteUserRequestImplCopyWith<_$DeleteUserRequestImpl> get copyWith =>
@@ -259,11 +249,8 @@ abstract class _DeleteUserRequest implements DeleteUserRequest {
   bool get deleteReviews;
   @override
   Map<String, dynamic>? get metadata;
-
-  /// Create a copy of DeleteUserRequest
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$DeleteUserRequestImplCopyWith<_$DeleteUserRequestImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/packages/apis/lib/network/remote/woocommerce/auth/freezed_model/request/send_reset_password_request.freezed.dart
+++ b/packages/apis/lib/network/remote/woocommerce/auth/freezed_model/request/send_reset_password_request.freezed.dart
@@ -26,12 +26,8 @@ mixin _$SendResetPasswordRequest {
   String? get resetUrl => throw _privateConstructorUsedError;
   Map<String, dynamic>? get metadata => throw _privateConstructorUsedError;
 
-  /// Serializes this SendResetPasswordRequest to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of SendResetPasswordRequest
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $SendResetPasswordRequestCopyWith<SendResetPasswordRequest> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -59,8 +55,6 @@ class _$SendResetPasswordRequestCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of SendResetPasswordRequest
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -110,8 +104,6 @@ class __$$SendResetPasswordRequestImplCopyWithImpl<$Res>
       $Res Function(_$SendResetPasswordRequestImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of SendResetPasswordRequest
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -179,14 +171,12 @@ class _$SendResetPasswordRequestImpl implements _SendResetPasswordRequest {
             const DeepCollectionEquality().equals(other._metadata, _metadata));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(runtimeType, email, resetUrl,
       const DeepCollectionEquality().hash(_metadata));
 
-  /// Create a copy of SendResetPasswordRequest
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$SendResetPasswordRequestImplCopyWith<_$SendResetPasswordRequestImpl>
@@ -217,11 +207,8 @@ abstract class _SendResetPasswordRequest implements SendResetPasswordRequest {
   String? get resetUrl;
   @override
   Map<String, dynamic>? get metadata;
-
-  /// Create a copy of SendResetPasswordRequest
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$SendResetPasswordRequestImplCopyWith<_$SendResetPasswordRequestImpl>
       get copyWith => throw _privateConstructorUsedError;
 }

--- a/packages/apis/lib/network/remote/woocommerce/auth/freezed_model/request/user_login_request.freezed.dart
+++ b/packages/apis/lib/network/remote/woocommerce/auth/freezed_model/request/user_login_request.freezed.dart
@@ -30,12 +30,8 @@ mixin _$UserLoginRequest {
   String? get deviceName => throw _privateConstructorUsedError;
   Map<String, dynamic>? get metadata => throw _privateConstructorUsedError;
 
-  /// Serializes this UserLoginRequest to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of UserLoginRequest
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $UserLoginRequestCopyWith<UserLoginRequest> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -65,8 +61,6 @@ class _$UserLoginRequestCopyWithImpl<$Res, $Val extends UserLoginRequest>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of UserLoginRequest
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -131,8 +125,6 @@ class __$$UserLoginRequestImplCopyWithImpl<$Res>
       $Res Function(_$UserLoginRequestImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of UserLoginRequest
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -232,14 +224,12 @@ class _$UserLoginRequestImpl implements _UserLoginRequest {
             const DeepCollectionEquality().equals(other._metadata, _metadata));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(runtimeType, email, password, rememberMe,
       deviceId, deviceName, const DeepCollectionEquality().hash(_metadata));
 
-  /// Create a copy of UserLoginRequest
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$UserLoginRequestImplCopyWith<_$UserLoginRequestImpl> get copyWith =>
@@ -281,11 +271,8 @@ abstract class _UserLoginRequest implements UserLoginRequest {
   String? get deviceName;
   @override
   Map<String, dynamic>? get metadata;
-
-  /// Create a copy of UserLoginRequest
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$UserLoginRequestImplCopyWith<_$UserLoginRequestImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/packages/apis/lib/network/remote/woocommerce/auth/freezed_model/request/user_signup_request.dart
+++ b/packages/apis/lib/network/remote/woocommerce/auth/freezed_model/request/user_signup_request.dart
@@ -9,6 +9,7 @@ class UserSignUpRequest with _$UserSignUpRequest {
   const factory UserSignUpRequest({
     required String email,
     required String password,
+    @JsonKey(name: 'AUTH_KEY') required String authKey,
     @JsonKey(name: 'first_name') required String firstName,
     @JsonKey(name: 'last_name') required String lastName,
     String? phone,

--- a/packages/apis/lib/network/remote/woocommerce/auth/freezed_model/request/user_signup_request.freezed.dart
+++ b/packages/apis/lib/network/remote/woocommerce/auth/freezed_model/request/user_signup_request.freezed.dart
@@ -22,6 +22,8 @@ UserSignUpRequest _$UserSignUpRequestFromJson(Map<String, dynamic> json) {
 mixin _$UserSignUpRequest {
   String get email => throw _privateConstructorUsedError;
   String get password => throw _privateConstructorUsedError;
+  @JsonKey(name: 'AUTH_KEY')
+  String get authKey => throw _privateConstructorUsedError;
   @JsonKey(name: 'first_name')
   String get firstName => throw _privateConstructorUsedError;
   @JsonKey(name: 'last_name')
@@ -36,12 +38,8 @@ mixin _$UserSignUpRequest {
   String? get referralCode => throw _privateConstructorUsedError;
   Map<String, dynamic>? get metadata => throw _privateConstructorUsedError;
 
-  /// Serializes this UserSignUpRequest to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of UserSignUpRequest
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $UserSignUpRequestCopyWith<UserSignUpRequest> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -55,6 +53,7 @@ abstract class $UserSignUpRequestCopyWith<$Res> {
   $Res call(
       {String email,
       String password,
+      @JsonKey(name: 'AUTH_KEY') String authKey,
       @JsonKey(name: 'first_name') String firstName,
       @JsonKey(name: 'last_name') String lastName,
       String? phone,
@@ -75,13 +74,12 @@ class _$UserSignUpRequestCopyWithImpl<$Res, $Val extends UserSignUpRequest>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of UserSignUpRequest
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
     Object? email = null,
     Object? password = null,
+    Object? authKey = null,
     Object? firstName = null,
     Object? lastName = null,
     Object? phone = freezed,
@@ -99,6 +97,10 @@ class _$UserSignUpRequestCopyWithImpl<$Res, $Val extends UserSignUpRequest>
       password: null == password
           ? _value.password
           : password // ignore: cast_nullable_to_non_nullable
+              as String,
+      authKey: null == authKey
+          ? _value.authKey
+          : authKey // ignore: cast_nullable_to_non_nullable
               as String,
       firstName: null == firstName
           ? _value.firstName
@@ -147,6 +149,7 @@ abstract class _$$UserSignUpRequestImplCopyWith<$Res>
   $Res call(
       {String email,
       String password,
+      @JsonKey(name: 'AUTH_KEY') String authKey,
       @JsonKey(name: 'first_name') String firstName,
       @JsonKey(name: 'last_name') String lastName,
       String? phone,
@@ -165,13 +168,12 @@ class __$$UserSignUpRequestImplCopyWithImpl<$Res>
       $Res Function(_$UserSignUpRequestImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of UserSignUpRequest
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
     Object? email = null,
     Object? password = null,
+    Object? authKey = null,
     Object? firstName = null,
     Object? lastName = null,
     Object? phone = freezed,
@@ -189,6 +191,10 @@ class __$$UserSignUpRequestImplCopyWithImpl<$Res>
       password: null == password
           ? _value.password
           : password // ignore: cast_nullable_to_non_nullable
+              as String,
+      authKey: null == authKey
+          ? _value.authKey
+          : authKey // ignore: cast_nullable_to_non_nullable
               as String,
       firstName: null == firstName
           ? _value.firstName
@@ -232,6 +238,7 @@ class _$UserSignUpRequestImpl implements _UserSignUpRequest {
   const _$UserSignUpRequestImpl(
       {required this.email,
       required this.password,
+      @JsonKey(name: 'AUTH_KEY') required this.authKey,
       @JsonKey(name: 'first_name') required this.firstName,
       @JsonKey(name: 'last_name') required this.lastName,
       this.phone,
@@ -249,6 +256,9 @@ class _$UserSignUpRequestImpl implements _UserSignUpRequest {
   final String email;
   @override
   final String password;
+  @override
+  @JsonKey(name: 'AUTH_KEY')
+  final String authKey;
   @override
   @JsonKey(name: 'first_name')
   final String firstName;
@@ -280,7 +290,7 @@ class _$UserSignUpRequestImpl implements _UserSignUpRequest {
 
   @override
   String toString() {
-    return 'UserSignUpRequest(email: $email, password: $password, firstName: $firstName, lastName: $lastName, phone: $phone, company: $company, acceptTerms: $acceptTerms, subscribeNewsletter: $subscribeNewsletter, referralCode: $referralCode, metadata: $metadata)';
+    return 'UserSignUpRequest(email: $email, password: $password, authKey: $authKey, firstName: $firstName, lastName: $lastName, phone: $phone, company: $company, acceptTerms: $acceptTerms, subscribeNewsletter: $subscribeNewsletter, referralCode: $referralCode, metadata: $metadata)';
   }
 
   @override
@@ -291,6 +301,7 @@ class _$UserSignUpRequestImpl implements _UserSignUpRequest {
             (identical(other.email, email) || other.email == email) &&
             (identical(other.password, password) ||
                 other.password == password) &&
+            (identical(other.authKey, authKey) || other.authKey == authKey) &&
             (identical(other.firstName, firstName) ||
                 other.firstName == firstName) &&
             (identical(other.lastName, lastName) ||
@@ -306,12 +317,13 @@ class _$UserSignUpRequestImpl implements _UserSignUpRequest {
             const DeepCollectionEquality().equals(other._metadata, _metadata));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(
       runtimeType,
       email,
       password,
+      authKey,
       firstName,
       lastName,
       phone,
@@ -321,9 +333,7 @@ class _$UserSignUpRequestImpl implements _UserSignUpRequest {
       referralCode,
       const DeepCollectionEquality().hash(_metadata));
 
-  /// Create a copy of UserSignUpRequest
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$UserSignUpRequestImplCopyWith<_$UserSignUpRequestImpl> get copyWith =>
@@ -342,6 +352,7 @@ abstract class _UserSignUpRequest implements UserSignUpRequest {
   const factory _UserSignUpRequest(
       {required final String email,
       required final String password,
+      @JsonKey(name: 'AUTH_KEY') required final String authKey,
       @JsonKey(name: 'first_name') required final String firstName,
       @JsonKey(name: 'last_name') required final String lastName,
       final String? phone,
@@ -358,6 +369,9 @@ abstract class _UserSignUpRequest implements UserSignUpRequest {
   String get email;
   @override
   String get password;
+  @override
+  @JsonKey(name: 'AUTH_KEY')
+  String get authKey;
   @override
   @JsonKey(name: 'first_name')
   String get firstName;
@@ -379,11 +393,8 @@ abstract class _UserSignUpRequest implements UserSignUpRequest {
   String? get referralCode;
   @override
   Map<String, dynamic>? get metadata;
-
-  /// Create a copy of UserSignUpRequest
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$UserSignUpRequestImplCopyWith<_$UserSignUpRequestImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/packages/apis/lib/network/remote/woocommerce/auth/freezed_model/request/user_signup_request.g.dart
+++ b/packages/apis/lib/network/remote/woocommerce/auth/freezed_model/request/user_signup_request.g.dart
@@ -11,6 +11,7 @@ _$UserSignUpRequestImpl _$$UserSignUpRequestImplFromJson(
     _$UserSignUpRequestImpl(
       email: json['email'] as String,
       password: json['password'] as String,
+      authKey: json['AUTH_KEY'] as String,
       firstName: json['first_name'] as String,
       lastName: json['last_name'] as String,
       phone: json['phone'] as String?,
@@ -26,6 +27,7 @@ Map<String, dynamic> _$$UserSignUpRequestImplToJson(
     <String, dynamic>{
       'email': instance.email,
       'password': instance.password,
+      'AUTH_KEY': instance.authKey,
       'first_name': instance.firstName,
       'last_name': instance.lastName,
       if (instance.phone case final value?) 'phone': value,

--- a/packages/apis/lib/network/remote/woocommerce/auth/freezed_model/response/delete_user_response.freezed.dart
+++ b/packages/apis/lib/network/remote/woocommerce/auth/freezed_model/response/delete_user_response.freezed.dart
@@ -27,12 +27,8 @@ mixin _$DeleteUserResponse {
   String? get error => throw _privateConstructorUsedError;
   Map<String, dynamic>? get metadata => throw _privateConstructorUsedError;
 
-  /// Serializes this DeleteUserResponse to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of DeleteUserResponse
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $DeleteUserResponseCopyWith<DeleteUserResponse> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -63,8 +59,6 @@ class _$DeleteUserResponseCopyWithImpl<$Res, $Val extends DeleteUserResponse>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of DeleteUserResponse
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -98,8 +92,6 @@ class _$DeleteUserResponseCopyWithImpl<$Res, $Val extends DeleteUserResponse>
     ) as $Val);
   }
 
-  /// Create a copy of DeleteUserResponse
-  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $DeleteUserDataCopyWith<$Res>? get data {
@@ -140,8 +132,6 @@ class __$$DeleteUserResponseImplCopyWithImpl<$Res>
       $Res Function(_$DeleteUserResponseImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of DeleteUserResponse
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -226,14 +216,12 @@ class _$DeleteUserResponseImpl implements _DeleteUserResponse {
             const DeepCollectionEquality().equals(other._metadata, _metadata));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(runtimeType, success, message, data, error,
       const DeepCollectionEquality().hash(_metadata));
 
-  /// Create a copy of DeleteUserResponse
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$DeleteUserResponseImplCopyWith<_$DeleteUserResponseImpl> get copyWith =>
@@ -262,18 +250,15 @@ abstract class _DeleteUserResponse implements DeleteUserResponse {
   @override
   bool get success;
   @override
-  String? get message; // Made nullable as server sometimes doesn't send message
-  @override
+  String? get message;
+  @override // Made nullable as server sometimes doesn't send message
   DeleteUserData? get data;
   @override
   String? get error;
   @override
   Map<String, dynamic>? get metadata;
-
-  /// Create a copy of DeleteUserResponse
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$DeleteUserResponseImplCopyWith<_$DeleteUserResponseImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -292,12 +277,8 @@ mixin _$DeleteUserData {
   bool? get reviewsDeleted => throw _privateConstructorUsedError;
   Map<String, dynamic>? get metadata => throw _privateConstructorUsedError;
 
-  /// Serializes this DeleteUserData to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of DeleteUserData
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $DeleteUserDataCopyWith<DeleteUserData> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -328,8 +309,6 @@ class _$DeleteUserDataCopyWithImpl<$Res, $Val extends DeleteUserData>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of DeleteUserData
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -400,8 +379,6 @@ class __$$DeleteUserDataImplCopyWithImpl<$Res>
       _$DeleteUserDataImpl _value, $Res Function(_$DeleteUserDataImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of DeleteUserData
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -506,7 +483,7 @@ class _$DeleteUserDataImpl implements _DeleteUserData {
             const DeepCollectionEquality().equals(other._metadata, _metadata));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(
       runtimeType,
@@ -518,9 +495,7 @@ class _$DeleteUserDataImpl implements _DeleteUserData {
       reviewsDeleted,
       const DeepCollectionEquality().hash(_metadata));
 
-  /// Create a copy of DeleteUserData
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$DeleteUserDataImplCopyWith<_$DeleteUserDataImpl> get copyWith =>
@@ -562,11 +537,8 @@ abstract class _DeleteUserData implements DeleteUserData {
   bool? get reviewsDeleted;
   @override
   Map<String, dynamic>? get metadata;
-
-  /// Create a copy of DeleteUserData
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$DeleteUserDataImplCopyWith<_$DeleteUserDataImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/packages/apis/lib/network/remote/woocommerce/auth/freezed_model/response/send_reset_password_response.freezed.dart
+++ b/packages/apis/lib/network/remote/woocommerce/auth/freezed_model/response/send_reset_password_response.freezed.dart
@@ -28,12 +28,8 @@ mixin _$SendResetPasswordResponse {
   String? get error => throw _privateConstructorUsedError;
   Map<String, dynamic>? get metadata => throw _privateConstructorUsedError;
 
-  /// Serializes this SendResetPasswordResponse to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of SendResetPasswordResponse
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $SendResetPasswordResponseCopyWith<SendResetPasswordResponse> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -65,8 +61,6 @@ class _$SendResetPasswordResponseCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of SendResetPasswordResponse
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -100,8 +94,6 @@ class _$SendResetPasswordResponseCopyWithImpl<$Res,
     ) as $Val);
   }
 
-  /// Create a copy of SendResetPasswordResponse
-  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $SendResetPasswordDataCopyWith<$Res>? get data {
@@ -145,8 +137,6 @@ class __$$SendResetPasswordResponseImplCopyWithImpl<$Res>
       $Res Function(_$SendResetPasswordResponseImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of SendResetPasswordResponse
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -231,14 +221,12 @@ class _$SendResetPasswordResponseImpl implements _SendResetPasswordResponse {
             const DeepCollectionEquality().equals(other._metadata, _metadata));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(runtimeType, success, message, data, error,
       const DeepCollectionEquality().hash(_metadata));
 
-  /// Create a copy of SendResetPasswordResponse
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$SendResetPasswordResponseImplCopyWith<_$SendResetPasswordResponseImpl>
@@ -267,18 +255,15 @@ abstract class _SendResetPasswordResponse implements SendResetPasswordResponse {
   @override
   bool get success;
   @override
-  String? get message; // Made nullable as server sometimes doesn't send message
-  @override
+  String? get message;
+  @override // Made nullable as server sometimes doesn't send message
   SendResetPasswordData? get data;
   @override
   String? get error;
   @override
   Map<String, dynamic>? get metadata;
-
-  /// Create a copy of SendResetPasswordResponse
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$SendResetPasswordResponseImplCopyWith<_$SendResetPasswordResponseImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -297,12 +282,8 @@ mixin _$SendResetPasswordData {
   String? get resetUrl => throw _privateConstructorUsedError;
   Map<String, dynamic>? get metadata => throw _privateConstructorUsedError;
 
-  /// Serializes this SendResetPasswordData to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of SendResetPasswordData
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $SendResetPasswordDataCopyWith<SendResetPasswordData> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -333,8 +314,6 @@ class _$SendResetPasswordDataCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of SendResetPasswordData
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -401,8 +380,6 @@ class __$$SendResetPasswordDataImplCopyWithImpl<$Res>
       $Res Function(_$SendResetPasswordDataImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of SendResetPasswordData
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -499,14 +476,12 @@ class _$SendResetPasswordDataImpl implements _SendResetPasswordData {
             const DeepCollectionEquality().equals(other._metadata, _metadata));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(runtimeType, email, resetToken, expiresAt,
       emailSent, resetUrl, const DeepCollectionEquality().hash(_metadata));
 
-  /// Create a copy of SendResetPasswordData
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$SendResetPasswordDataImplCopyWith<_$SendResetPasswordDataImpl>
@@ -545,11 +520,8 @@ abstract class _SendResetPasswordData implements SendResetPasswordData {
   String? get resetUrl;
   @override
   Map<String, dynamic>? get metadata;
-
-  /// Create a copy of SendResetPasswordData
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$SendResetPasswordDataImplCopyWith<_$SendResetPasswordDataImpl>
       get copyWith => throw _privateConstructorUsedError;
 }

--- a/packages/apis/lib/network/remote/woocommerce/auth/freezed_model/response/user_login_response.freezed.dart
+++ b/packages/apis/lib/network/remote/woocommerce/auth/freezed_model/response/user_login_response.freezed.dart
@@ -27,12 +27,8 @@ mixin _$UserLoginResponse {
   String? get error => throw _privateConstructorUsedError;
   Map<String, dynamic>? get metadata => throw _privateConstructorUsedError;
 
-  /// Serializes this UserLoginResponse to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of UserLoginResponse
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $UserLoginResponseCopyWith<UserLoginResponse> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -63,8 +59,6 @@ class _$UserLoginResponseCopyWithImpl<$Res, $Val extends UserLoginResponse>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of UserLoginResponse
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -98,8 +92,6 @@ class _$UserLoginResponseCopyWithImpl<$Res, $Val extends UserLoginResponse>
     ) as $Val);
   }
 
-  /// Create a copy of UserLoginResponse
-  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $UserLoginDataCopyWith<$Res>? get data {
@@ -140,8 +132,6 @@ class __$$UserLoginResponseImplCopyWithImpl<$Res>
       $Res Function(_$UserLoginResponseImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of UserLoginResponse
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -226,14 +216,12 @@ class _$UserLoginResponseImpl implements _UserLoginResponse {
             const DeepCollectionEquality().equals(other._metadata, _metadata));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(runtimeType, success, message, data, error,
       const DeepCollectionEquality().hash(_metadata));
 
-  /// Create a copy of UserLoginResponse
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$UserLoginResponseImplCopyWith<_$UserLoginResponseImpl> get copyWith =>
@@ -262,18 +250,15 @@ abstract class _UserLoginResponse implements UserLoginResponse {
   @override
   bool get success;
   @override
-  String? get message; // Made nullable as server sometimes doesn't send message
-  @override
+  String? get message;
+  @override // Made nullable as server sometimes doesn't send message
   UserLoginData? get data;
   @override
   String? get error;
   @override
   Map<String, dynamic>? get metadata;
-
-  /// Create a copy of UserLoginResponse
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$UserLoginResponseImplCopyWith<_$UserLoginResponseImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -296,12 +281,8 @@ mixin _$UserLoginData {
   DateTime? get issuedAt => throw _privateConstructorUsedError;
   DateTime? get expiresAt => throw _privateConstructorUsedError;
 
-  /// Serializes this UserLoginData to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of UserLoginData
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $UserLoginDataCopyWith<UserLoginData> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -336,8 +317,6 @@ class _$UserLoginDataCopyWithImpl<$Res, $Val extends UserLoginData>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of UserLoginData
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -391,8 +370,6 @@ class _$UserLoginDataCopyWithImpl<$Res, $Val extends UserLoginData>
     ) as $Val);
   }
 
-  /// Create a copy of UserLoginData
-  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $UserInfoCopyWith<$Res>? get user {
@@ -437,8 +414,6 @@ class __$$UserLoginDataImplCopyWithImpl<$Res>
       _$UserLoginDataImpl _value, $Res Function(_$UserLoginDataImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of UserLoginData
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -558,14 +533,12 @@ class _$UserLoginDataImpl implements _UserLoginData {
                 other.expiresAt == expiresAt));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(runtimeType, jwt, accessToken, tokenType,
       expiresIn, refreshToken, scope, user, issuedAt, expiresAt);
 
-  /// Create a copy of UserLoginData
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$UserLoginDataImplCopyWith<_$UserLoginDataImpl> get copyWith =>
@@ -595,10 +568,10 @@ abstract class _UserLoginData implements UserLoginData {
       _$UserLoginDataImpl.fromJson;
 
   @override
-  String? get jwt; // JWT token field from server response
-  @override
-  String? get accessToken; // Alternative access token field
-  @override
+  String? get jwt;
+  @override // JWT token field from server response
+  String? get accessToken;
+  @override // Alternative access token field
   String? get tokenType;
   @override
   int? get expiresIn;
@@ -612,11 +585,8 @@ abstract class _UserLoginData implements UserLoginData {
   DateTime? get issuedAt;
   @override
   DateTime? get expiresAt;
-
-  /// Create a copy of UserLoginData
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$UserLoginDataImplCopyWith<_$UserLoginDataImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -643,12 +613,8 @@ mixin _$UserInfo {
   bool? get isActive => throw _privateConstructorUsedError;
   bool? get isVerified => throw _privateConstructorUsedError;
 
-  /// Serializes this UserInfo to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of UserInfo
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $UserInfoCopyWith<UserInfo> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -686,8 +652,6 @@ class _$UserInfoCopyWithImpl<$Res, $Val extends UserInfo>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of UserInfo
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -806,8 +770,6 @@ class __$$UserInfoImplCopyWithImpl<$Res>
       _$UserInfoImpl _value, $Res Function(_$UserInfoImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of UserInfo
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -1007,7 +969,7 @@ class _$UserInfoImpl implements _UserInfo {
                 other.isVerified == isVerified));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(
       runtimeType,
@@ -1027,9 +989,7 @@ class _$UserInfoImpl implements _UserInfo {
       isActive,
       isVerified);
 
-  /// Create a copy of UserInfo
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$UserInfoImplCopyWith<_$UserInfoImpl> get copyWith =>
@@ -1094,11 +1054,8 @@ abstract class _UserInfo implements UserInfo {
   bool? get isActive;
   @override
   bool? get isVerified;
-
-  /// Create a copy of UserInfo
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$UserInfoImplCopyWith<_$UserInfoImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/packages/apis/lib/network/remote/woocommerce/auth/freezed_model/response/user_signup_response.freezed.dart
+++ b/packages/apis/lib/network/remote/woocommerce/auth/freezed_model/response/user_signup_response.freezed.dart
@@ -27,12 +27,8 @@ mixin _$UserSignUpResponse {
   String? get error => throw _privateConstructorUsedError;
   Map<String, dynamic>? get metadata => throw _privateConstructorUsedError;
 
-  /// Serializes this UserSignUpResponse to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of UserSignUpResponse
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $UserSignUpResponseCopyWith<UserSignUpResponse> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -63,8 +59,6 @@ class _$UserSignUpResponseCopyWithImpl<$Res, $Val extends UserSignUpResponse>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of UserSignUpResponse
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -98,8 +92,6 @@ class _$UserSignUpResponseCopyWithImpl<$Res, $Val extends UserSignUpResponse>
     ) as $Val);
   }
 
-  /// Create a copy of UserSignUpResponse
-  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $UserSignUpDataCopyWith<$Res>? get data {
@@ -140,8 +132,6 @@ class __$$UserSignUpResponseImplCopyWithImpl<$Res>
       $Res Function(_$UserSignUpResponseImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of UserSignUpResponse
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -226,14 +216,12 @@ class _$UserSignUpResponseImpl implements _UserSignUpResponse {
             const DeepCollectionEquality().equals(other._metadata, _metadata));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(runtimeType, success, message, data, error,
       const DeepCollectionEquality().hash(_metadata));
 
-  /// Create a copy of UserSignUpResponse
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$UserSignUpResponseImplCopyWith<_$UserSignUpResponseImpl> get copyWith =>
@@ -262,18 +250,15 @@ abstract class _UserSignUpResponse implements UserSignUpResponse {
   @override
   bool get success;
   @override
-  String? get message; // Made nullable as server sometimes doesn't send message
-  @override
+  String? get message;
+  @override // Made nullable as server sometimes doesn't send message
   UserSignUpData? get data;
   @override
   String? get error;
   @override
   Map<String, dynamic>? get metadata;
-
-  /// Create a copy of UserSignUpResponse
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$UserSignUpResponseImplCopyWith<_$UserSignUpResponseImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -295,12 +280,8 @@ mixin _$UserSignUpData {
   DateTime? get createdAt => throw _privateConstructorUsedError;
   Map<String, dynamic>? get metadata => throw _privateConstructorUsedError;
 
-  /// Serializes this UserSignUpData to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of UserSignUpData
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $UserSignUpDataCopyWith<UserSignUpData> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -334,8 +315,6 @@ class _$UserSignUpDataCopyWithImpl<$Res, $Val extends UserSignUpData>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of UserSignUpData
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -424,8 +403,6 @@ class __$$UserSignUpDataImplCopyWithImpl<$Res>
       _$UserSignUpDataImpl _value, $Res Function(_$UserSignUpDataImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of UserSignUpData
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -559,7 +536,7 @@ class _$UserSignUpDataImpl implements _UserSignUpData {
             const DeepCollectionEquality().equals(other._metadata, _metadata));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(
       runtimeType,
@@ -574,9 +551,7 @@ class _$UserSignUpDataImpl implements _UserSignUpData {
       createdAt,
       const DeepCollectionEquality().hash(_metadata));
 
-  /// Create a copy of UserSignUpData
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$UserSignUpDataImplCopyWith<_$UserSignUpDataImpl> get copyWith =>
@@ -627,11 +602,8 @@ abstract class _UserSignUpData implements UserSignUpData {
   DateTime? get createdAt;
   @override
   Map<String, dynamic>? get metadata;
-
-  /// Create a copy of UserSignUpData
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$UserSignUpDataImplCopyWith<_$UserSignUpDataImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/packages/apis/lib/services/auth/woo_auth_manager.dart
+++ b/packages/apis/lib/services/auth/woo_auth_manager.dart
@@ -129,6 +129,7 @@ class WooAuthManager {
   Future<WooAuthResult<UserSignUpData>> signUp({
     required String email,
     required String password,
+    required String authKey,
     required String firstName,
     required String lastName,
     String? phone,
@@ -144,6 +145,7 @@ class WooAuthManager {
       final request = UserSignUpRequest(
         email: email,
         password: password,
+        authKey: authKey,
         firstName: firstName,
         lastName: lastName,
         phone: phone,

--- a/projects/api_explorer/lib/services/handlers/woocommerce/auth_handlers/user_signup_handler.dart
+++ b/projects/api_explorer/lib/services/handlers/woocommerce/auth_handlers/user_signup_handler.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:get_it/get_it.dart';
 import 'package:apis/network/remote/woocommerce/auth/abstract/woo_auth_service.dart';
 import 'package:apis/network/remote/woocommerce/auth/freezed_model/request/user_signup_request.dart';
+import 'package:apis/apis.dart';
 
 ///*******************************************************************
 ///******************* 📝 USER SIGNUP HANDLER **********************
@@ -23,7 +24,15 @@ class UserSignUpHandler implements ApiRequestHandler {
       };
     }
 
-    // Validate required parameters
+    // Validate required parameters (Postman parameters)
+    if (!params.containsKey('rest_route') || params['rest_route']!.isEmpty) {
+      return {
+        "status": "error",
+        "message": "REST route is required",
+        "timestamp": DateTime.now().toIso8601String(),
+      };
+    }
+
     if (!params.containsKey('email') || params['email']!.isEmpty) {
       return {
         "status": "error",
@@ -40,67 +49,52 @@ class UserSignUpHandler implements ApiRequestHandler {
       };
     }
 
-    if (!params.containsKey('first_name') || params['first_name']!.isEmpty) {
+    if (!params.containsKey('AUTH_KEY') || params['AUTH_KEY']!.isEmpty) {
       return {
         "status": "error",
-        "message": "First name is required",
-        "timestamp": DateTime.now().toIso8601String(),
-      };
-    }
-
-    if (!params.containsKey('last_name') || params['last_name']!.isEmpty) {
-      return {
-        "status": "error",
-        "message": "Last name is required",
-        "timestamp": DateTime.now().toIso8601String(),
-      };
-    }
-
-    if (!params.containsKey('brand_name') || params['brand_name']!.isEmpty) {
-      return {
-        "status": "error",
-        "message": "Store name is required",
+        "message": "AUTH_KEY is required",
         "timestamp": DateTime.now().toIso8601String(),
       };
     }
 
     try {
+      final restRoute = params['rest_route']!;
       final email = params['email']!;
       final password = params['password']!;
-      final firstName = params['first_name']!;
-      final lastName = params['last_name']!;
-      final storeName = params['brand_name']!;
-      final phone =
-          params['phone']?.isNotEmpty == true ? params['phone'] : null;
-      final company =
-          params['company']?.isNotEmpty == true ? params['company'] : null;
-      final acceptTerms = params['accept_terms']?.toLowerCase() == 'true';
-      final subscribeNewsletter =
-          params['subscribe_newsletter']?.toLowerCase() == 'true';
-      final referralCode = params['referral_code']?.isNotEmpty == true
-          ? params['referral_code']
-          : null;
+      final authKey = params['AUTH_KEY']!;
 
-      debugPrint('📝 Starting user sign up for: $email in store: $storeName');
+      debugPrint('📝 Starting user sign up for: $email');
+      debugPrint('📝 REST Route: $restRoute');
+      debugPrint('📝 Auth Key: ${authKey.substring(0, 10)}...');
+
+      // Extract brand name from rest_route
+      final brandName = restRoute.split('-')[0].replaceAll('/', '');
+      debugPrint('📝 Extracted brand name: $brandName');
+
+      // Debug network configuration
+      debugPrint('🌐 Base URL: ${WooNetwork.baseUrl}');
+      debugPrint(
+          '🌐 Full endpoint will be: ${WooNetwork.baseUrl}/?rest_route=/$brandName-auth-login/v1/users');
 
       // Use WooAuthService from the package
       final authService = GetIt.I<WooAuthService>();
 
-      // Create signup request
+      // Create signup request with minimal required fields
       final signupRequest = UserSignUpRequest(
         email: email,
         password: password,
-        firstName: firstName,
-        lastName: lastName,
-        phone: phone,
-        company: company,
-        acceptTerms: acceptTerms,
-        subscribeNewsletter: subscribeNewsletter,
-        referralCode: referralCode,
+        authKey: authKey,
+        firstName: '', // Not required in Postman
+        lastName: '', // Not required in Postman
+        phone: null,
+        company: null,
+        acceptTerms: true,
+        subscribeNewsletter: false,
+        referralCode: null,
       );
 
-      // Use store name from parameters
-      final response = await authService.userSignUp(storeName, signupRequest);
+      // Use brand name from rest_route
+      final response = await authService.userSignUp(brandName, signupRequest);
 
       if (response.success) {
         debugPrint('✅ User sign up successful');
@@ -183,9 +177,9 @@ class UserSignUpHandler implements ApiRequestHandler {
   Map<String, List<ApiField>> get requiredFields => {
         'POST': [
           const ApiField(
-            name: 'brand_name',
-            label: 'Store Name',
-            hint: 'WooCommerce store name',
+            name: 'rest_route',
+            label: 'REST Route',
+            hint: 'API endpoint route',
             isRequired: true,
           ),
           const ApiField(
@@ -201,41 +195,10 @@ class UserSignUpHandler implements ApiRequestHandler {
             isRequired: true,
           ),
           const ApiField(
-            name: 'first_name',
-            label: 'First Name',
-            hint: 'User first name',
+            name: 'AUTH_KEY',
+            label: 'Auth Key',
+            hint: 'Authentication key for API access',
             isRequired: true,
-          ),
-          const ApiField(
-            name: 'last_name',
-            label: 'Last Name',
-            hint: 'User last name',
-            isRequired: true,
-          ),
-          const ApiField(
-            name: 'phone',
-            label: 'Phone',
-            hint: 'User phone number',
-          ),
-          const ApiField(
-            name: 'company',
-            label: 'Company',
-            hint: 'User company name',
-          ),
-          const ApiField(
-            name: 'accept_terms',
-            label: 'Accept Terms',
-            hint: 'Accept terms and conditions (true/false)',
-          ),
-          const ApiField(
-            name: 'subscribe_newsletter',
-            label: 'Subscribe Newsletter',
-            hint: 'Subscribe to newsletter (true/false)',
-          ),
-          const ApiField(
-            name: 'referral_code',
-            label: 'Referral Code',
-            hint: 'Referral code if any',
           ),
         ],
       };

--- a/projects/api_explorer/lib/widgets/store_management/store_setup_wizard.dart
+++ b/projects/api_explorer/lib/widgets/store_management/store_setup_wizard.dart
@@ -4,6 +4,7 @@ import 'package:apis/apis.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:core/core.dart';
 import '../../services/handlers/woocommerce/auth_handlers/jwt_auth_test_handler.dart';
+import '../../services/handlers/woocommerce/auth_handlers/user_signup_handler.dart';
 
 class StoreSetupWizard extends StatefulWidget {
   final Function(StoreConfiguration)? onStoreAdded;
@@ -96,6 +97,7 @@ class _StoreSetupWizardState extends State<StoreSetupWizard>
 
   // Authentication testing state
   bool _isTestingAuth = false;
+  bool _isSigningUp = false;
   String? _authTestResult;
 
   // Controllers for form fields
@@ -110,6 +112,11 @@ class _StoreSetupWizardState extends State<StoreSetupWizard>
   final _customerEmailController = TextEditingController();
   final _customerPasswordController = TextEditingController();
   final _authEndpointController = TextEditingController();
+
+  // Sign up fields (Postman parameters only)
+  final _signupEmailController = TextEditingController();
+  final _signupPasswordController = TextEditingController();
+  final _signupAuthKeyController = TextEditingController();
 
   // Password visibility states
   bool _isAccessTokenVisible = false;
@@ -167,16 +174,16 @@ class _StoreSetupWizardState extends State<StoreSetupWizard>
       // Update tab states when store name changes
       if (mounted) setState(() {});
     });
-    
+
     // Add listeners to WooCommerce store configuration fields to update tab states
     _storeUrlController.addListener(() {
       if (mounted) setState(() {});
     });
-    
+
     _usernameController.addListener(() {
       if (mounted) setState(() {});
     });
-    
+
     _passwordController.addListener(() {
       if (mounted) setState(() {});
     });
@@ -357,7 +364,9 @@ class _StoreSetupWizardState extends State<StoreSetupWizard>
 
   /// Show warning when trying to access Customer Authentication without completing Store Configuration
   Widget _buildStoreConfigurationWarning() {
-    if (_selectedPlatform != 'woocommerce' || _currentTab != 'store' || _isStoreConfigurationComplete()) {
+    if (_selectedPlatform != 'woocommerce' ||
+        _currentTab != 'store' ||
+        _isStoreConfigurationComplete()) {
       return const SizedBox.shrink();
     }
 
@@ -414,9 +423,9 @@ class _StoreSetupWizardState extends State<StoreSetupWizard>
     }
 
     return _storeNameController.text.trim().isNotEmpty &&
-           _storeUrlController.text.trim().isNotEmpty &&
-           _usernameController.text.trim().isNotEmpty &&
-           _passwordController.text.trim().isNotEmpty;
+        _storeUrlController.text.trim().isNotEmpty &&
+        _usernameController.text.trim().isNotEmpty &&
+        _passwordController.text.trim().isNotEmpty;
   }
 
   /// Test WooCommerce JWT Authentication
@@ -487,6 +496,76 @@ class _StoreSetupWizardState extends State<StoreSetupWizard>
     } finally {
       setState(() {
         _isTestingAuth = false;
+      });
+    }
+  }
+
+  /// Sign up new user using WooCommerce auth
+  Future<void> _signUpUser() async {
+    if (_signupEmailController.text.isEmpty ||
+        _signupPasswordController.text.isEmpty ||
+        _signupAuthKeyController.text.isEmpty) {
+      setState(() {
+        _authTestResult =
+            'Please fill in email, password and AUTH_KEY for sign up';
+      });
+      return;
+    }
+
+    setState(() {
+      _isSigningUp = true;
+      _authTestResult = null;
+    });
+
+    try {
+      debugPrint('📝 Starting user sign up...');
+
+      // Get brand name from current store configuration or use store name
+      final brandName = await WizardHelper.getBrandNameForAuth();
+      final effectiveBrandName =
+          brandName.isNotEmpty ? brandName : _storeNameController.text.trim();
+
+      // Use the User Sign Up Handler
+      final handler = UserSignUpHandler();
+
+      // Get password as raw string and convert safely
+      final rawPassword = _signupPasswordController.text;
+      final safePassword = _convertPasswordToSafeString(rawPassword);
+
+      final params = <String, String>{
+        'rest_route': '/$effectiveBrandName-auth-login/v1/users',
+        'email': _signupEmailController.text.trim(),
+        'password': safePassword,
+        'AUTH_KEY': _signupAuthKeyController.text.trim(),
+      };
+
+      final result = await handler.handleRequest('POST', params);
+
+      if (result['status'] == 'success') {
+        setState(() {
+          _authTestResult =
+              '✅ User sign up successful!\n\n👤 User created:\n${result['user_data']}';
+        });
+        debugPrint('✅ User sign up successful');
+
+        // Clear sign up form
+        _signupEmailController.clear();
+        _signupPasswordController.clear();
+        _signupAuthKeyController.clear();
+      } else {
+        setState(() {
+          _authTestResult = '❌ Sign up failed: ${result['message']}';
+        });
+        debugPrint('❌ User sign up failed: ${result['message']}');
+      }
+    } catch (e) {
+      setState(() {
+        _authTestResult = '❌ Sign up error: ${e.toString()}';
+      });
+      debugPrint('❌ User sign up error: $e');
+    } finally {
+      setState(() {
+        _isSigningUp = false;
       });
     }
   }
@@ -949,6 +1028,9 @@ class _StoreSetupWizardState extends State<StoreSetupWizard>
     _customerEmailController.dispose();
     _customerPasswordController.dispose();
     _authEndpointController.dispose();
+    _signupEmailController.dispose();
+    _signupPasswordController.dispose();
+    _signupAuthKeyController.dispose();
     super.dispose();
   }
 
@@ -1203,7 +1285,7 @@ class _StoreSetupWizardState extends State<StoreSetupWizard>
           final isCustomerTab = tab == 'customer';
           final isStoreConfigComplete = _isStoreConfigurationComplete();
           final isTabDisabled = isCustomerTab && !isStoreConfigComplete;
-          
+
           // Define tab icons with proper styling
           IconData tabIcon;
           if (tab == 'store') {
@@ -1213,7 +1295,7 @@ class _StoreSetupWizardState extends State<StoreSetupWizard>
           } else {
             tabIcon = Icons.settings_outlined;
           }
-          
+
           return OsmeaComponents.expanded(
             child: OsmeaComponents.container(
               margin: EdgeInsets.symmetric(horizontal: context.spacing4),
@@ -1224,24 +1306,27 @@ class _StoreSetupWizardState extends State<StoreSetupWizard>
                   opacity: isTabDisabled ? 0.5 : 1.0,
                   child: OsmeaComponents.button(
                     text: tabName,
-                    variant: isActive ? ButtonVariant.primary : ButtonVariant.ghost,
-                    size: ButtonSize.small, // Changed from medium to small for smaller text
+                    variant:
+                        isActive ? ButtonVariant.primary : ButtonVariant.ghost,
+                    size: ButtonSize
+                        .small, // Changed from medium to small for smaller text
                     icon: Icon(
                       tabIcon,
                       size: 18, // Reduced icon size to match smaller text
                       color: isTabDisabled
-                        ? OsmeaColors.steel.withValues(alpha: 0.4)
-                        : isActive 
-                          ? Colors.white 
-                          : OsmeaColors.steel.withValues(alpha: 0.8),
+                          ? OsmeaColors.steel.withValues(alpha: 0.4)
+                          : isActive
+                              ? Colors.white
+                              : OsmeaColors.steel.withValues(alpha: 0.8),
                     ),
                     onPressed: () {
                       // Check if trying to access Customer Authentication without completing Store Configuration
-                      if (tab == 'customer' && !_isStoreConfigurationComplete()) {
+                      if (tab == 'customer' &&
+                          !_isStoreConfigurationComplete()) {
                         // Don't switch tab, stay on store configuration
                         return;
                       }
-                      
+
                       setState(() {
                         _currentTab = tab;
                       });
@@ -1608,6 +1693,89 @@ class _StoreSetupWizardState extends State<StoreSetupWizard>
               ],
             ),
           ),
+
+        OsmeaComponents.sizedBox(height: context.spacing24),
+
+        // Sign Up Section
+        OsmeaComponents.container(
+          padding: context.paddingNormal,
+          decoration: BoxDecoration(
+            color: OsmeaColors.blue.withValues(alpha: 0.05),
+            borderRadius: context.borderRadiusNormal,
+            border: Border.all(
+              color: OsmeaColors.blue.withValues(alpha: 0.2),
+            ),
+          ),
+          child: OsmeaComponents.column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              OsmeaComponents.row(
+                children: [
+                  Icon(
+                    Icons.person_add,
+                    color: OsmeaColors.blue,
+                    size: 24,
+                  ),
+                  OsmeaComponents.sizedBox(width: context.spacing12),
+                  OsmeaComponents.text(
+                    'Create New User Account',
+                    textStyle: OsmeaTextStyle.titleLarge(context),
+                    color: OsmeaColors.blue,
+                  ),
+                ],
+              ),
+
+              OsmeaComponents.sizedBox(height: context.spacing16),
+
+              // Sign up form fields (Postman parameters)
+              OsmeaComponents.textField(
+                controller: _signupEmailController,
+                label: 'Email *',
+                hint: 'Enter email address',
+                keyboardType: TextInputType.emailAddress,
+              ),
+
+              OsmeaComponents.sizedBox(height: context.spacing16),
+
+              OsmeaComponents.textField(
+                controller: _signupPasswordController,
+                label: 'Password *',
+                hint: 'Enter password',
+                obscureText: true,
+              ),
+
+              OsmeaComponents.sizedBox(height: context.spacing16),
+
+              OsmeaComponents.textField(
+                controller: _signupAuthKeyController,
+                label: 'AUTH_KEY *',
+                hint: 'Enter authentication key',
+              ),
+
+              OsmeaComponents.sizedBox(height: context.spacing16),
+
+              // Sign Up Button
+              OsmeaComponents.button(
+                text: _isSigningUp ? 'Creating Account...' : 'Create Account',
+                onPressed: _isSigningUp ? null : _signUpUser,
+                variant: ButtonVariant.secondary,
+                size: ButtonSize.medium,
+                icon: _isSigningUp
+                    ? SizedBox(
+                        width: 20,
+                        height: 20,
+                        child: CircularProgressIndicator(
+                          strokeWidth: 2,
+                          valueColor: AlwaysStoppedAnimation<Color>(
+                            OsmeaColors.white,
+                          ),
+                        ),
+                      )
+                    : Icon(Icons.person_add),
+              ),
+            ],
+          ),
+        ),
 
         OsmeaComponents.sizedBox(height: context.spacing24),
 


### PR DESCRIPTION
## 📋 PR Description
This PR extends the **WooCommerce authentication module** by adding **`authKey` support** to the **user sign-up flow**.
The `authKey` ensures that new user registrations are securely tied to the selected store and validated before issuing JWT tokens.


### ✨ What’s Included

| Area                    | Details                                                                                               |
| ----------------------- | ----------------------------------------------------------------------------------------------------- |
| **WooAuthManager**      | Updated `signUp` method to accept an `authKey` parameter, ensuring store-level validation.            |
| **ApiDioClient**        | Extended `signUpUser` request method to forward `authKey` securely.                                   |
| **ApiWooAuthService**   | Corrected signup endpoint and integrated `authKey` into request handling.                             |
| **User Request Models** | Refactored models to ignore unnecessary JSON serialization fields and include new `authKey` property. |
| **Signup Handler**      | Updated logic to validate new signup parameters, including `authKey`.                                 |
| **StoreSetupWizard**    | Implemented full signup flow with `authKey` validation and error handling.                            |

---

### 🔐 Signup Flow Update

```mermaid
graph TD
  A[Select Store] --> B[Signup Request with authKey]
  B --> C[WooAuthService validates authKey]
  C --> D[User Created Successfully]
```

> \[!IMPORTANT]
> The `authKey` is **mandatory** for signup requests.
> Without a valid `authKey`, the server rejects the signup attempt.

---


### ✅ Outcomes

* More secure **store-scoped signup flow** via `authKey`.
* Improved **user request models** with cleaner JSON serialization.
* Store Setup Wizard now provides **end-to-end signup experience** with validation.

> \[!NOTE]
> This change enforces a stricter validation layer, making it impossible to sign up users outside the scope of an authenticated store.

---

## ✅ Checklist

- [X] Code follows the project standards and guidelines.
- [X] Relevant unit tests are written and all tests are passing.
- [X] Test coverage is adequate for the changes.
- [X] Any unnecessary files or debug statements have been removed.
- [X] Documentation is updated where necessary.
- [X] The PR has been reviewed by at least one team member before merging.

---

## 🛠 Steps to Test


1. **Store Selection**

   * Connect a store in the Store Setup Wizard.
   * Confirm `authKey` is generated and attached for signup requests.

2. **Signup Flow**

   * Create a new user through the signup form.
   * Verify that `authKey` is included in the network request payload.
   * Ensure signup succeeds only with a valid `authKey`.

3. **Error Handling**

   * Attempt signup with invalid/expired `authKey`.
   * Confirm request is rejected with proper error message.
   * UI should display validation error, not proceed silently.

---

## 🔗 Related Links

- Issue: https://github.com/masterfabric-mobile/osmea/issues/170
- Documentation: https://woocommerce.github.io/woocommerce-rest-api-docs/?javascript#authentication

---

### 📷 Screenshots (Optional)

<img width="1680" height="1050" alt="sign-up" src="https://github.com/user-attachments/assets/ffd030be-56ea-4919-abf5-ca9f60fcc9d3" />
<img width="1680" height="1050" alt="sign-up-response" src="https://github.com/user-attachments/assets/a001a544-7b99-4224-9d11-8f8edff125a0" />
