### PR TITLE
Core -> Core-Base-View-Cubit-Export

### DIFF
--- a/packages/core/lib/core.dart
+++ b/packages/core/lib/core.dart
@@ -10,6 +10,9 @@ export 'package:core/src/base/base_view_model.dart';
 // 🧠 Exports the base cubit class View Models
 export 'package:core/src/base/base_view_model_cubit.dart';
 
+// 🧠 Exports the base cubit class View Models
+export 'package:core/src/base/base_view_cubit.dart';
+
 // 🧩 Exports the base class for Master App
 export 'package:core/src/base/master_view/master_app.dart';
 

--- a/packages/core/lib/src/base/base_view_cubit.dart
+++ b/packages/core/lib/src/base/base_view_cubit.dart
@@ -52,7 +52,7 @@ typedef OnCubitStateListener<S> = void Function(BuildContext context, S? state);
 /// ```dart
 /// buildWhen: (previous, current) => previous != current,
 /// ```
-typedef BuilderCondition<S> = bool Function(S? previous, S? current);
+typedef BuilderConditionCubit<S> = bool Function(S? previous, S? current);
 
 /// 🌟
 /// BaseViewCubit simplifies lifecycle, state listening, and builder management with Cubit-based ViewModel.
@@ -80,7 +80,7 @@ class BaseViewCubit<V extends BaseViewModelCubit<S>, S> extends StatefulWidget {
   final OnCubitStateListener<S>? onStateListener;
 
   /// 🔄 Condition to determine builder call.
-  final BuilderCondition<S>? buildWhen;
+  final BuilderConditionCubit<S>? buildWhen;
 
   /// 🗺️ Global key for navigation, dialogs, and bottom sheets.
   static final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();


### PR DESCRIPTION
## 📋 PR Description
<!-- Provide a brief description of the changes introduced by this PR. -->
**Fix:** Added missing exports and resolved naming conflicts for Base Cubit classes

This PR addresses multiple issues in the core package:
1. Added missing export statement for `BaseViewCubit` class in core.dart
2. Resolved typedef naming conflict by refactoring `BuilderCondition` to `BuilderConditionCubit`

The `BaseViewCubit` class was implemented but not exported, making it inaccessible to package consumers. Additionally, there was a naming conflict with the `BuilderCondition` typedef that could cause import collisions.

**Changes:**
- Added `export 'package:core/src/base/base_view_cubit.dart';` to `core.dart`
- Refactored `BuilderCondition` typedef to `BuilderConditionCubit` in `base_view_cubit.dart`
- Updated all references to use the new typedef name

---
## ✅ Checklist
- [x] Code follows the project standards and guidelines.
- [x] Relevant unit tests are written and all tests are passing.
- [x] Test coverage is adequate for the changes.
- [x] Any unnecessary files or debug statements have been removed.
- [x] Documentation is updated where necessary.
- [x] The PR has been reviewed by at least one team member before merging.
---
## 🛠 Steps to Test
<!-- Provide a clear, step-by-step description of how to test the changes introduced by this PR. -->
1. Create a new Flutter project that depends on this package
2. Import the core package: `import 'package:core/core.dart';`
3. Try to extend `BaseViewCubit` class in your code
4. Verify that the class is now accessible and no import errors occur
5. Test that `BuilderConditionCubit` typedef works correctly without naming conflicts
6. Import both ViewModel and Cubit classes together to verify no conflicts exist
7. Run `flutter analyze` to ensure no static analysis issues
8. Run existing tests to confirm no breaking changes
9. Build the project to ensure compilation succeeds

### 📷 Screenshots (Optional)
<!-- Attach any relevant screenshots to illustrate the changes, especially for UI updates. -->
N/A - This is a code export fix and refactoring, no UI changes involved.

### 🚨 Breaking Changes
**Note:** The typedef name change from `BuilderCondition` to `BuilderConditionCubit` is a breaking change for any existing consumers using this typedef. Consider updating the package version accordingly (minor/major version bump).