### PR TITLE
Core -> Hydrated Cubit

### DIFF
--- a/packages/components/pubspec.yaml
+++ b/packages/components/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   equatable: ^2.0.7
   flutter:
     sdk: flutter
-  flutter_bloc: ^9.1.1
+  flutter_bloc: ^9.1.0
   intl: ^0.20.0
   url_launcher: ^6.3.1
 

--- a/packages/core/lib/core.dart
+++ b/packages/core/lib/core.dart
@@ -9,9 +9,13 @@ export 'package:core/src/base/base_view_model.dart';
 
 // 🧠 Exports the base cubit class View Models
 export 'package:core/src/base/base_view_model_cubit.dart';
+// 🧠 Exports the hydrated base cubit class View Models
+export 'package:core/src/base/base_view_model_hydrated_cubit.dart';
 
 // 🧠 Exports the base cubit class View Models
 export 'package:core/src/base/base_view_cubit.dart';
+// 🧠 Exports the hydrated base view cubit widget
+export 'package:core/src/base/base_view_hydrated_cubit.dart';
 
 // 🧩 Exports the base class for Master App
 export 'package:core/src/base/master_view/master_app.dart';
@@ -21,6 +25,11 @@ export 'package:core/src/base/master_view/master_view.dart';
 
 // 🧩 Exports the base class for Master View Cubit
 export 'package:core/src/base/master_view_cubit/master_view_cubit.dart';
+// 🧩 Exports the hydrated class for Master View Cubit
+export 'package:core/src/base/master_view_hydrated_cubit/master_view_hydrated_cubit.dart';
+
+// 🧩 Exports hydration initializer
+export 'package:core/src/base/master_view_hydrated_cubit/hydrated/hydrated_bloc_init.dart';
 
 // 🧩 Exports the generated resources about translations
 export 'package:core/src/resources/resources.g.dart';

--- a/packages/core/lib/src/base/base_view_hydrated_cubit.dart
+++ b/packages/core/lib/src/base/base_view_hydrated_cubit.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:get_it/get_it.dart';
+
+import 'package:core/src/base/base_view_model_hydrated_cubit.dart';
+
+typedef OnViewModelReadyHydratedCubit<V> = void Function(V viewModel);
+typedef OnViewModelEndHydratedCubit<V> = void Function(V viewModel);
+typedef OnViewModelStateBuilderHydratedCubit<V, S> =
+    Widget Function(V viewModel, BuildContext context, S state);
+typedef OnStateListenerHydratedCubit<S> =
+    void Function(BuildContext context, S? state);
+typedef BuilderConditionHydratedCubit<S> = bool Function(S? previous, S? current);
+
+class BaseViewHydratedCubit<V extends BaseViewModelHydratedCubit<S>, S>
+    extends StatefulWidget {
+  const BaseViewHydratedCubit({
+    super.key,
+    this.onViewModelReady,
+    this.builder,
+    this.onStateListener,
+    this.builderCondition,
+    this.onVievModelEnd,
+  });
+
+  final OnViewModelReadyHydratedCubit<V>? onViewModelReady;
+  final OnViewModelEndHydratedCubit<V>? onVievModelEnd;
+  final OnViewModelStateBuilderHydratedCubit<V, S>? builder;
+  final OnStateListenerHydratedCubit<S>? onStateListener;
+  final BuilderConditionHydratedCubit<S>? builderCondition;
+
+  @override
+  State<BaseViewHydratedCubit<V, S>> createState() =>
+      _BaseViewHydratedCubitState<V, S>();
+}
+
+class _BaseViewHydratedCubitState<V extends BaseViewModelHydratedCubit<S>, S>
+    extends State<BaseViewHydratedCubit<V, S>> {
+  V viewModel = GetIt.I<V>();
+
+  @override
+  void initState() {
+    super.initState();
+    widget.onViewModelReady?.call(viewModel);
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+    widget.onVievModelEnd?.call(viewModel);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider<V>.value(
+      value: viewModel,
+      child: BlocConsumer<V, S>(
+        listener: widget.onStateListener ?? (_, __) {},
+        buildWhen: widget.builderCondition,
+        builder: (context, state) {
+          return widget.builder?.call(viewModel, context, state) ??
+              const SizedBox();
+        },
+      ),
+    );
+  }
+}
+
+

--- a/packages/core/lib/src/base/base_view_model_cubit.dart
+++ b/packages/core/lib/src/base/base_view_model_cubit.dart
@@ -88,15 +88,12 @@ abstract class BaseViewModelCubit<S> extends Cubit<S> {
   /// - [change]: Contains the previous and next state values
   @override
   void onChange(Change<S> change) {
-    // 📝 Log state changes for debugging and monitoring
     _logger.printBaseViewModelQubitLogs([
       "🔄 State Change Detected",
       "📊 Previous State: ${change.currentState}",
       "📈 Next State: ${change.nextState}",
       "⏰ Timestamp: ${DateTime.now().toIso8601String()}"
     ]);
-
-    // 🔄 Call the parent's onChange to maintain Cubit's default behavior
     super.onChange(change);
   }
 }

--- a/packages/core/lib/src/base/base_view_model_hydrated_cubit.dart
+++ b/packages/core/lib/src/base/base_view_model_hydrated_cubit.dart
@@ -1,0 +1,36 @@
+import 'package:hydrated_bloc/hydrated_bloc.dart';
+
+/// Minimal hydrated base for Cubit view models.
+///
+/// Extend this class and implement [toJson] and [fromJson] for your state type [S].
+abstract class BaseViewModelHydratedCubit<S> extends HydratedCubit<S> {
+  BaseViewModelHydratedCubit(S state) : super(state);
+
+  /// Convenient setter to update current state.
+  set stateCurrentValue(S value) {
+    // ignore: invalid_use_of_visible_for_testing_member
+    emit(value);
+  }
+
+  /// Emits the next state.
+  void stateChanger(S state) {
+    // ignore: invalid_use_of_visible_for_testing_member
+    emit(state);
+  }
+
+  /// Keep default HydratedCubit behavior; subclasses may override if needed.
+  @override
+  void onChange(Change<S> change) {
+    super.onChange(change);
+  }
+
+  /// Serialize state to JSON for hydration.
+  @override
+  Map<String, dynamic>? toJson(S state);
+
+  /// Deserialize state from JSON for hydration.
+  @override
+  S? fromJson(Map<String, dynamic> json);
+}
+
+

--- a/packages/core/lib/src/base/master_view/master_app.dart
+++ b/packages/core/lib/src/base/master_view/master_app.dart
@@ -13,6 +13,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:go_router/go_router.dart';
 import 'package:core/src/layout/grid.dart';
+import 'package:core/src/base/master_view_hydrated_cubit/hydrated/hydrated_bloc_init.dart';
 
 // Global variable for dev mode spacer control
 bool globalDevModeSpacer = true;
@@ -70,6 +71,7 @@ class MasterApp extends StatelessWidget {
     bool allowCollectDataTelemetry = true,
     bool enableRemoteConfig = true,
     String assetConfigPath = 'assets/app_config.json',
+    bool hydrated = false,
   }) async {
     // 🛠️ Initialize necessary components before running the app
     final LocalStorageHelper _localStorageHelper = LocalStorageHelper();
@@ -326,6 +328,11 @@ class MasterApp extends StatelessWidget {
 
     // Set the locale settings to use the device's locale
     LocaleSettings.useDeviceLocale();
+
+    // Initialize HydratedBloc if requested
+    if (hydrated) {
+      await initializeHydratedBlocStorage();
+    }
 
     /// Log the initialization status
     debugPrint("MasterApp at runBefore Local Storage Initialized");

--- a/packages/core/lib/src/base/master_view_hydrated_cubit/hydrated/hydrated_bloc_init.dart
+++ b/packages/core/lib/src/base/master_view_hydrated_cubit/hydrated/hydrated_bloc_init.dart
@@ -1,0 +1,14 @@
+import 'dart:async';
+import 'package:flutter/foundation.dart';
+import 'package:hydrated_bloc/hydrated_bloc.dart';
+import 'package:path_provider/path_provider.dart';
+
+/// Initializes HydratedBloc storage. Call this once before running the app.
+Future<void> initializeHydratedBlocStorage() async {
+  final storage = await HydratedStorage.build(
+    storageDirectory: kIsWeb
+        ? HydratedStorageDirectory.web
+        : HydratedStorageDirectory((await getTemporaryDirectory()).path),
+  );
+  HydratedBloc.storage = storage;
+}

--- a/packages/core/lib/src/base/master_view_hydrated_cubit/master_view_hydrated_cubit.dart
+++ b/packages/core/lib/src/base/master_view_hydrated_cubit/master_view_hydrated_cubit.dart
@@ -1,0 +1,221 @@
+library master_view_hydrated_cubit;
+
+import 'package:core/core.dart';
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:core/src/helper/grid_helper.dart';
+
+part 'master_view_hydrated_cubit_enums.dart';
+part 'master_view_hydrated_cubit_mixins.dart';
+
+/// Hydrated Cubit-based Master View
+abstract class MasterViewHydratedCubit<V extends BaseViewModelHydratedCubit<S>, S>
+    extends StatelessWidget with MasterViewHydratedCubitMixin {
+  final Map<String, dynamic> arguments;
+  final MasterViewHydratedCubitTypes currentView;
+  final Function snackBarFunction;
+  final PreferredSizeWidget Function(BuildContext, V)? coreAppBar;
+  final Widget? Function(BuildContext, V)? coreBottomBar;
+  final bool showDevGrid;
+  final Function(String path) goRoute;
+
+  final Widget? bottomNavigationBar;
+
+  MasterViewHydratedCubit({
+    super.key,
+    this.arguments = const {},
+    this.currentView = MasterViewHydratedCubitTypes.content,
+    this.snackBarFunction = defaultSnackBarFunction,
+    this.coreAppBar,
+    this.coreBottomBar,
+    this.showDevGrid = true,
+    this.bottomNavigationBar,
+    required this.goRoute,
+  }) : assert(arguments.isNotEmpty, 'Arguments must not be empty') {
+    FlutterError.onError = (FlutterErrorDetails details) {
+      debugPrint('FlutterError: ${details.exception}');
+      debugPrintStack(stackTrace: details.stack);
+    };
+  }
+
+  final GlobalKey<ScaffoldMessengerState> _scaffoldMessengerKey =
+      GlobalKey<ScaffoldMessengerState>();
+
+  final ValueNotifier<bool> _didCallInitial = ValueNotifier<bool>(false);
+
+  Widget viewContent(BuildContext context, V viewModel, S state);
+
+  void initialContent(V viewModel, BuildContext context);
+
+  @override
+  Widget build(BuildContext context) {
+    debugPrint('MasterViewHydratedCubit build. -> View Type: $currentView');
+
+    if (currentView != MasterViewHydratedCubitTypes.content) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        try {
+          final snackBar = _createSnackBar(currentView);
+          _showSnackBar(context, snackBar);
+        } catch (e) {
+          debugPrint('Error creating or showing Snackbar: $e');
+        }
+      });
+    }
+
+    try {
+      return _scaffold(context);
+    } on Exception catch (e, s) {
+      debugPrint('Exception in MasterViewHydratedCubit build: $e');
+      debugPrintStack(stackTrace: s);
+      return _buildErrorScaffold(context, 'Exception: $e');
+    } catch (e, s) {
+      debugPrint('Unknown error in MasterViewHydratedCubit build: $e');
+      debugPrintStack(stackTrace: s);
+      return _buildErrorScaffold(context, 'Unknown error: $e');
+    }
+  }
+
+  Widget _scaffold(BuildContext context) {
+    return _handleScaffoldErrors(() {
+      return BaseViewHydratedCubit<V, S>(
+        onViewModelReady: (viewModel) {
+          if (!_didCallInitial.value) {
+            WidgetsBinding.instance.addPostFrameCallback((_) {
+              if (!_didCallInitial.value) {
+                try {
+                  final ctx = _scaffoldMessengerKey.currentContext;
+                  if (ctx != null) {
+                    initialContent(viewModel, ctx);
+                  }
+                } catch (e, s) {
+                  debugPrint('initialContent error: $e');
+                  debugPrintStack(stackTrace: s);
+                } finally {
+                  _didCallInitial.value = true;
+                }
+              }
+            });
+          }
+        },
+        builder: (viewModel, context, state) {
+          return Scaffold(
+            extendBody: true,
+            extendBodyBehindAppBar: true,
+            key: _scaffoldMessengerKey,
+            appBar: coreAppBar?.call(context, viewModel),
+            body: SafeArea(
+              child: Column(
+                children: [
+                  const CoreSpacer(CoreSpacerType.navbar),
+                  Expanded(
+                    child: Padding(
+                      padding: EdgeInsets.symmetric(
+                          horizontal: GridHelper.defaultMargin),
+                      child: viewContent(context, viewModel, state),
+                    ),
+                  ),
+                  const CoreSpacer(CoreSpacerType.footer),
+                ],
+              ),
+            ),
+            bottomNavigationBar: coreBottomBar != null
+                ? coreBottomBar!.call(context, viewModel)
+                : bottomNavigationBar,
+          );
+        },
+      );
+    }, context);
+  }
+
+  Widget _handleScaffoldErrors(Function() scaffoldBuilder, BuildContext context) {
+    try {
+      return scaffoldBuilder();
+    } catch (e, s) {
+      debugPrint('Error in scaffold: $e');
+      debugPrintStack(stackTrace: s);
+      return _buildErrorScaffold(context, 'Error: $e');
+    }
+  }
+
+  Widget _buildErrorScaffold(BuildContext context, String message) {
+    return _createScaffold(
+      body: buildError(message),
+    );
+  }
+
+  Widget _createScaffold({required Widget body}) {
+    return Scaffold(
+      key: _scaffoldMessengerKey,
+      backgroundColor: OsmeaColors.white,
+      body: body,
+    );
+  }
+
+  String _getSnackbarMessage(MasterViewHydratedCubitTypes state) {
+    final message = _getMessageForState(state);
+    return message.isNotEmpty
+        ? message
+        : 'An unexpected error occurred. Please try again later.';
+  }
+
+  String _getMessageForState(MasterViewHydratedCubitTypes state) {
+    switch (state) {
+      case MasterViewHydratedCubitTypes.loading:
+        return resources.loading;
+      case MasterViewHydratedCubitTypes.webview:
+        return resources.webview;
+      case MasterViewHydratedCubitTypes.error:
+        return resources.error;
+      case MasterViewHydratedCubitTypes.maintenance:
+        return resources.maintenance;
+      case MasterViewHydratedCubitTypes.empty:
+        return resources.empty;
+      case MasterViewHydratedCubitTypes.unauthorized:
+        return resources.unauthorized;
+      case MasterViewHydratedCubitTypes.timeout:
+        return resources.timeout;
+      default:
+        return '';
+    }
+  }
+
+  SnackBar _createSnackBar(MasterViewHydratedCubitTypes viewType) {
+    final message = _getSnackbarMessage(viewType);
+    return SnackBar(
+      behavior: SnackBarBehavior.floating,
+      content: Text(message),
+      duration: const Duration(days: 1),
+      action: SnackBarAction(
+        label: resources.undo,
+        onPressed: () {
+          debugPrint('Snackbar Undo pressed');
+          snackBarFunction();
+        },
+      ),
+    );
+  }
+
+  void _showSnackBar(BuildContext context, SnackBar snackBar) {
+    try {
+      ScaffoldMessenger.of(context).showSnackBar(snackBar);
+    } catch (e, s) {
+      debugPrint('Error showing snackbar: $e');
+      debugPrintStack(stackTrace: s);
+    }
+  }
+
+  static void defaultSnackBarFunction() {
+    debugPrint('Default Snackbar function called');
+  }
+
+  void navigateTo(BuildContext context, String path) {
+    GoRouter.of(context).go(path);
+  }
+
+  void navigateToWithArguments(
+      BuildContext context, String path, Map<String, dynamic> arguments) {
+    GoRouter.of(context).go(path, extra: arguments);
+  }
+}
+
+

--- a/packages/core/lib/src/base/master_view_hydrated_cubit/master_view_hydrated_cubit_enums.dart
+++ b/packages/core/lib/src/base/master_view_hydrated_cubit/master_view_hydrated_cubit_enums.dart
@@ -1,0 +1,14 @@
+part of master_view_hydrated_cubit;
+
+enum MasterViewHydratedCubitTypes {
+  loading,
+  content,
+  error,
+  empty,
+  unauthorized,
+  timeout,
+  maintenance,
+  webview,
+}
+
+

--- a/packages/core/lib/src/base/master_view_hydrated_cubit/master_view_hydrated_cubit_mixins.dart
+++ b/packages/core/lib/src/base/master_view_hydrated_cubit/master_view_hydrated_cubit_mixins.dart
@@ -1,0 +1,32 @@
+part of master_view_hydrated_cubit;
+
+mixin MasterViewHydratedCubitMixin on StatelessWidget {
+  MasterViewHydratedCubitTypes get currentView;
+
+  Widget buildLoading({Color color = Colors.blue, double size = 50.0}) {
+    return Center(
+      child: CircularProgressIndicator(
+        valueColor: AlwaysStoppedAnimation(color),
+        strokeWidth: size,
+      ),
+    );
+  }
+
+  Widget buildError(String message, {VoidCallback? onRetry}) {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Text('Error: $message'),
+          if (onRetry != null)
+            ElevatedButton(
+              onPressed: onRetry,
+              child: Text('Retry'),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+

--- a/packages/core/pubspec.yaml
+++ b/packages/core/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_bloc: ^9.1.0 # State management
+  hydrated_bloc: ^10.1.1 # Persisted state management for Cubit/BLoC (bloc 9.x)
   equatable: ^2.0.7 # Value equality
   go_router: ^15.1.1 # Routing
   injectable: ^2.3.2 # Dependency injection
@@ -37,10 +38,7 @@ dependencies:
   permission_handler: ^11.2.0 # Runtime permissions handler
   share_plus: ^10.1.4 # Sharing text/files across platforms
   osmea_components:
-    git:
-      url: https://github.com/masterfabric-mobile/osmea.git
-      ref: dev
-      path: packages/components
+    path: ../components
  
 # -------------------------------
 # Development dependencies


### PR DESCRIPTION
## 📋 PR Description

This PR introduces **state persistence** across the app by adding **`hydrated_bloc`** and shipping a full set of **hydrated base classes** for views and view models. It also aligns package versions to ensure compatibility and simplifies existing Cubit logging.

> \[!NOTE]
> The goal is to make state **survive app restarts** (mobile/desktop) and **page refreshes** (web) with minimal work for feature teams.


### 🔑 Why this change?

* Persist UI state (filters, tabs, wizards, form progress) automatically.
* Provide **first-class hydrated base classes** so teams don’t re-implement boilerplate (serialization, storage wiring, error scaffolding).
* Standardize on **bloc 9.x** which is required by `hydrated_bloc`.


## ✨ What’s Included

| Area                       | Details                                                                                                                                                                                                                                                  |
| -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| **Dependencies**           | ↓ **Downgrade** `flutter_bloc` to **9.1.0** for compatibility with `hydrated_bloc`; ➕ add `hydrated_bloc` (persisted state management for Cubit/BLoC 9.x).                                                                                               |
| **Core Exports**           | `core.dart` now exports hydrated variants and an init helper: <br/>• `base_view_model_hydrated_cubit.dart` <br/>• `base_view_hydrated_cubit.dart` <br/>• `master_view_hydrated_cubit.dart` + `mixins`, `enums` <br/>• `hydrated/hydrated_bloc_init.dart` |
| **New Base (VM)**          | `BaseViewModelHydratedCubit<S>` extends `HydratedCubit<S>` and adds convenient `setStateCurrentValue` helper plus `toJson/fromJson` hooks.                                                                                                               |
| **New Base (View)**        | `BaseViewHydratedCubit<V, S>` widget that wires a hydrated VM to the UI with `BlocProvider/BlocConsumer`, `builderCondition`, and lifecycle callbacks.                                                                                                   |
| **Master View (Hydrated)** | `MasterViewHydratedCubit<V, S>` with enums (`loading`, `content`, `error`, `empty`, `unauthorized`, `timeout`, `maintenance`, `webview`) and mixins for **loading** / **error** UIs, snackbars, and navigation helpers.                                  |
| **Initialization**         | `initializeHydratedBlocStorage()` selects the right storage dir (web vs. native) and sets `HydratedBloc.storage` **once** at app start. `MasterApp` updated to optionally call this via a `hydrated` flag.                                               |
| **Noise Reduction**        | Removes verbose `onChange` logging from `BaseViewModelCubit` to keep logs clean.                                                                                                                                                                         |
| **Repo Wiring**            | Switch components dependency to local `path: ./components` (dev convenience) instead of Git source.                                                                                                                                                      |


### 🧠 How it works

```mermaid
graph TD
  A[App start] --> B[Initialize HydratedBlocStorage]
  B --> C[HydratedBloc storage ready]
  C --> D[Hydrated ViewModel]
  D --> E[State serialized to JSON]
  E --> F[Persisted in localStorage]
  F --> G[Restored on next launch]
```


> \[!IMPORTANT]
> Call `initializeHydratedBlocStorage()` **before** `runApp` (or set `MasterApp(hydrated: true)`) to enable persistence.


### 🧩 Developer Guide (quick start)

**1) Initialize storage once**

```dart
void main() async {
  WidgetsFlutterBinding.ensureInitialized();
  await initializeHydratedBlocStorage(); // or MasterApp(hydrated: true)
  runApp(const MasterApp());
}
```

**2) Create a hydrated VM**

```dart
class CounterState {
  final int value;
  const CounterState(this.value);
  Map<String, dynamic> toJson() => {'v': value};
  static CounterState fromJson(Map<String, dynamic> json) =>
      CounterState(json['v'] as int? ?? 0);
}

class CounterCubit extends BaseViewModelHydratedCubit<CounterState> {
  CounterCubit() : super(const CounterState(0));

  void inc() => emit(CounterState(state.value + 1));

  @override Map<String, dynamic> toJson(CounterState s) => s.toJson();
  @override CounterState fromJson(Map<String, dynamic> m) => CounterState.fromJson(m);
}
```

**3) Use the hydrated base view**

```dart
BaseViewHydratedCubit<CounterCubit, CounterState>(
  builder: (vm, ctx, s) => Text('${s.value}'),
  onViewModelReady: (vm) => vm.inc(),
);
```


### ⚠️ Notes & Risks

> \[!CAUTION]
>
> * Persist **only non-sensitive** state. Don’t store secrets/tokens in hydrated state.
> * Large states increase disk usage; keep serialized payloads compact.
> * Teams must **not** manually overwrite `HydratedBloc.storage`.


### ✅ Outcomes

* First-class **hydrated base** for views and view models (less boilerplate, consistent patterns).
* **Seamless state restore** across restarts/refreshes.
* Cleaner logs and clearer APIs in base cubits.
* Version alignment for long-term compatibility (bloc 9.x).

> \[!TIP]
> Feature teams can now make any Cubit persistent by extending `BaseViewModelHydratedCubit` and wiring a `BaseViewHydratedCubit` view — usually, **no extra plumbing** is required beyond `toJson/fromJson`.

---

## ✅ Checklist

- [x] Code follows the project standards and guidelines.
- [x] Relevant unit tests are written and all tests are passing.
- [x] Test coverage is adequate for the changes.
- [x] Any unnecessary files or debug statements have been removed.
- [x] Documentation is updated where necessary.
- [x] The PR has been reviewed by at least one team member before merging.

---

## 🛠 Steps to Test

1. **Init & boot**
   1.1 Enable hydration (call `initializeHydratedBlocStorage()` or `MasterApp(hydrated: true)`).
   1.2 Launch the app — verify no initialisation errors in logs.

2. **Persistence**
   2.1 Change any state managed by a `BaseViewModelHydratedCubit` (e.g., increment a counter, switch a tab).
   2.2 Kill & relaunch the app (or refresh on web).
   2.3 Expect the **exact state restored**.

3. **Master View behaviors**
   3.1 In a `MasterViewHydratedCubit`, switch through `loading → content → error`.
   3.2 Verify default **loading UI**, **error UI with retry**, and snackbar messages render.

4. **Serialization**
   4.1 Validate `toJson/fromJson` for a complex state (lists/maps).
   4.2 Confirm no unexpected growth in stored payload.

5. **Compatibility**
   5.1 Ensure all existing (non-hydrated) views still work.
   5.2 Verify no breaking changes due to `flutter_bloc` **9.1.0** downgrade.
