### PR TITLE
OSMEA - FIX -> Components - TextField

### DIFF
--- a/packages/components/lib/src/components/text_field/text_field.dart
+++ b/packages/components/lib/src/components/text_field/text_field.dart
@@ -430,7 +430,8 @@ class _OsmeaTextFieldView extends StatelessWidget {
       suffixIcon: textField.suffixIcon != null
           ? _buildIcon(textField.suffixIcon!, config, colors, state)
           : null,
-      filled: textField.variant == TextFieldVariant.filled ||
+      filled: textField.backgroundColor != null ||
+          textField.variant == TextFieldVariant.filled ||
           textField.variant == TextFieldVariant.borderless,
       fillColor: colors.background,
       contentPadding: textField.customContentPadding ?? config.padding,

--- a/projects/components_app/lib/components/text_field_example.dart
+++ b/projects/components_app/lib/components/text_field_example.dart
@@ -344,7 +344,7 @@ class _TextFieldExampleState extends State<TextFieldExample> {
             ScaffoldMessenger.of(context).showSnackBar(
               SnackBar(
                 content: OsmeaComponents.text('6-digit OTP completed: $otp'),
-                backgroundColor: OsmeaColors.forestHeart,
+                backgroundColor: OsmeaColors.orange,
               ),
             );
           },
@@ -389,11 +389,11 @@ class _TextFieldExampleState extends State<TextFieldExample> {
         OsmeaComponents.otpTextField(
           digitCount: 5,
           size: TextFieldSize.large,
-          variant: TextFieldVariant.underlined,
+          variant: TextFieldVariant.filled,
           spacing: 16.0,
           obscureText: true, // Hidden digits for security
-          backgroundColor: OsmeaColors.nordicBlue.withValues(alpha: 0.05),
-          focusColor: OsmeaColors.nordicBlue,
+          backgroundColor: OsmeaColors.orange,
+          focusColor: OsmeaColors.orange,
           borderColor: OsmeaColors.silver,
           onChanged: (otp) =>
               debugPrint('5-digit secure OTP changed: ${'*' * otp.length}'),
@@ -402,7 +402,7 @@ class _TextFieldExampleState extends State<TextFieldExample> {
             ScaffoldMessenger.of(context).showSnackBar(
               SnackBar(
                 content: OsmeaComponents.text('Secure OTP completed!'),
-                backgroundColor: OsmeaColors.nordicBlue,
+                backgroundColor: OsmeaColors.orange,
               ),
             );
           },
@@ -501,9 +501,9 @@ class _TextFieldExampleState extends State<TextFieldExample> {
         OsmeaComponents.textField(
           label: 'Custom Themed TextField',
           hint: 'This field has custom colors',
-          variant: TextFieldVariant.outlined,
+          variant: TextFieldVariant.filled,
           size: TextFieldSize.medium,
-          backgroundColor: OsmeaColors.nordicBlue.withValues(alpha: 0.05),
+          backgroundColor: OsmeaColors.orange,
           borderColor: OsmeaColors.nordicBlue,
           focusColor: OsmeaColors.forestHeart,
           textColor: OsmeaColors.slate,


### PR DESCRIPTION
## 📋 PR Description

This PR updates the TextField widget logic to ensure that the filled property is correctly set when a backgroundColor is provided.
Previously, the filled flag only checked for the TextFieldVariant.filled, which caused the background color to be ignored in certain cases.
The new logic is as follows:

```dart
filled: textField.backgroundColor != null ||
        textField.variant == TextFieldVariant.filled
```
---

## ✅ Checklist

- [x] Code follows the project standards and guidelines.
- [ ] Relevant unit tests are written and all tests are passing.
- [x] Test coverage is adequate for the changes.
- [ ] Any unnecessary files or debug statements have been removed.
- [ ] Documentation is updated where necessary.
- [x] The PR has been reviewed by at least one team member before merging.

---

## 🛠 Steps to Test

1. Open any example using TextFieldWidget.
2. Set a custom backgroundColor for the text field.
3. Confirm that the field background is now visible even when the variant is not filled.
4. Also verify that existing filled variants behave as expected.

---

## 🔗 Related Links

- Issue: https://github.com/masterfabric-mobile/osmea/issues/180

---

## 💻 Contributors
@nisacolak 
@NurhayatYurtaslan 

---
### 📷 Screenshots (Optional)
| <img src="https://github.com/user-attachments/assets/7d4dc8af-efb5-4809-bce7-2b0696d0612c" alt="Eski Hali" width="300"> | <img src="https://github.com/user-attachments/assets/a93bf75d-6b89-40b4-b007-448c1bb0d802" alt="Yeni Hali" width="300"> |
