### PR TITLE
Core -> Account View Update Signout And Using Style 

### DIFF
--- a/packages/apis/lib/network/remote/woocommerce/auth/freezed_model/response/get_users_me_response.dart
+++ b/packages/apis/lib/network/remote/woocommerce/auth/freezed_model/response/get_users_me_response.dart
@@ -8,146 +8,121 @@ import 'dart:convert';
 part 'get_users_me_response.freezed.dart';
 part 'get_users_me_response.g.dart';
 
-GetUsersMeResponse getUsersMeResponseFromJson(String str) => GetUsersMeResponse.fromJson(json.decode(str));
+GetUsersMeResponse getUsersMeResponseFromJson(String str) =>
+    GetUsersMeResponse.fromJson(json.decode(str));
 
-String getUsersMeResponseToJson(GetUsersMeResponse data) => json.encode(data.toJson());
+String getUsersMeResponseToJson(GetUsersMeResponse data) =>
+    json.encode(data.toJson());
 
 @freezed
 class GetUsersMeResponse with _$GetUsersMeResponse {
-    const factory GetUsersMeResponse({
-        @JsonKey(name: "id")
-        int? id,
-        @JsonKey(name: "name")
-        String? name,
-        @JsonKey(name: "url")
-        String? url,
-        @JsonKey(name: "description")
-        String? description,
-        @JsonKey(name: "link")
-        String? link,
-        @JsonKey(name: "slug")
-        String? slug,
-        @JsonKey(name: "avatar_urls")
-        AvatarUrls? avatarUrls,
-        @JsonKey(name: "meta")
-        List<dynamic>? meta,
-        @JsonKey(name: "is_super_admin")
-        bool? isSuperAdmin,
-        @JsonKey(name: "woocommerce_meta")
-        WoocommerceMeta? woocommerceMeta,
-        @JsonKey(name: "_links")
-        Links? links,
-    }) = _GetUsersMeResponse;
+  const factory GetUsersMeResponse({
+    @JsonKey(name: "id") int? id,
+    @JsonKey(name: "name") String? name,
+    @JsonKey(name: "url") String? url,
+    @JsonKey(name: "description") String? description,
+    @JsonKey(name: "link") String? link,
+    @JsonKey(name: "slug") String? slug,
+    @JsonKey(name: "avatar_urls") AvatarUrls? avatarUrls,
+    @JsonKey(name: "meta")
+    dynamic meta, // Can be List or Map depending on API version
+    @JsonKey(name: "is_super_admin") bool? isSuperAdmin,
+    @JsonKey(name: "woocommerce_meta") WoocommerceMeta? woocommerceMeta,
+    @JsonKey(name: "_links") Links? links,
+  }) = _GetUsersMeResponse;
 
-    factory GetUsersMeResponse.fromJson(Map<String, dynamic> json) => _$GetUsersMeResponseFromJson(json);
+  factory GetUsersMeResponse.fromJson(Map<String, dynamic> json) =>
+      _$GetUsersMeResponseFromJson(json);
 }
 
 @freezed
 class AvatarUrls with _$AvatarUrls {
-    const factory AvatarUrls({
-        @JsonKey(name: "24")
-        String? the24,
-        @JsonKey(name: "48")
-        String? the48,
-        @JsonKey(name: "96")
-        String? the96,
-    }) = _AvatarUrls;
+  const factory AvatarUrls({
+    @JsonKey(name: "24") String? the24,
+    @JsonKey(name: "48") String? the48,
+    @JsonKey(name: "96") String? the96,
+  }) = _AvatarUrls;
 
-    factory AvatarUrls.fromJson(Map<String, dynamic> json) => _$AvatarUrlsFromJson(json);
+  factory AvatarUrls.fromJson(Map<String, dynamic> json) =>
+      _$AvatarUrlsFromJson(json);
 }
 
 @freezed
 class Links with _$Links {
-    const factory Links({
-        @JsonKey(name: "self")
-        List<Self>? self,
-        @JsonKey(name: "collection")
-        List<Collection>? collection,
-    }) = _Links;
+  const factory Links({
+    @JsonKey(name: "self") List<Self>? self,
+    @JsonKey(name: "collection") List<Collection>? collection,
+  }) = _Links;
 
-    factory Links.fromJson(Map<String, dynamic> json) => _$LinksFromJson(json);
+  factory Links.fromJson(Map<String, dynamic> json) => _$LinksFromJson(json);
 }
 
 @freezed
 class Collection with _$Collection {
-    const factory Collection({
-        @JsonKey(name: "href")
-        String? href,
-    }) = _Collection;
+  const factory Collection({
+    @JsonKey(name: "href") String? href,
+  }) = _Collection;
 
-    factory Collection.fromJson(Map<String, dynamic> json) => _$CollectionFromJson(json);
+  factory Collection.fromJson(Map<String, dynamic> json) =>
+      _$CollectionFromJson(json);
 }
 
 @freezed
 class Self with _$Self {
-    const factory Self({
-        @JsonKey(name: "href")
-        String? href,
-        @JsonKey(name: "targetHints")
-        TargetHints? targetHints,
-    }) = _Self;
+  const factory Self({
+    @JsonKey(name: "href") String? href,
+    @JsonKey(name: "targetHints") TargetHints? targetHints,
+  }) = _Self;
 
-    factory Self.fromJson(Map<String, dynamic> json) => _$SelfFromJson(json);
+  factory Self.fromJson(Map<String, dynamic> json) => _$SelfFromJson(json);
 }
 
 @freezed
 class TargetHints with _$TargetHints {
-    const factory TargetHints({
-        @JsonKey(name: "allow")
-        List<String>? allow,
-    }) = _TargetHints;
+  const factory TargetHints({
+    @JsonKey(name: "allow") List<String>? allow,
+  }) = _TargetHints;
 
-    factory TargetHints.fromJson(Map<String, dynamic> json) => _$TargetHintsFromJson(json);
+  factory TargetHints.fromJson(Map<String, dynamic> json) =>
+      _$TargetHintsFromJson(json);
 }
 
 @freezed
 class WoocommerceMeta with _$WoocommerceMeta {
-    const factory WoocommerceMeta({
-        @JsonKey(name: "variable_product_tour_shown")
-        String? variableProductTourShown,
-        @JsonKey(name: "activity_panel_inbox_last_read")
-        String? activityPanelInboxLastRead,
-        @JsonKey(name: "activity_panel_reviews_last_read")
-        String? activityPanelReviewsLastRead,
-        @JsonKey(name: "categories_report_columns")
-        String? categoriesReportColumns,
-        @JsonKey(name: "coupons_report_columns")
-        String? couponsReportColumns,
-        @JsonKey(name: "customers_report_columns")
-        String? customersReportColumns,
-        @JsonKey(name: "orders_report_columns")
-        String? ordersReportColumns,
-        @JsonKey(name: "products_report_columns")
-        String? productsReportColumns,
-        @JsonKey(name: "revenue_report_columns")
-        String? revenueReportColumns,
-        @JsonKey(name: "taxes_report_columns")
-        String? taxesReportColumns,
-        @JsonKey(name: "variations_report_columns")
-        String? variationsReportColumns,
-        @JsonKey(name: "dashboard_sections")
-        String? dashboardSections,
-        @JsonKey(name: "dashboard_chart_type")
-        String? dashboardChartType,
-        @JsonKey(name: "dashboard_chart_interval")
-        String? dashboardChartInterval,
-        @JsonKey(name: "dashboard_leaderboard_rows")
-        String? dashboardLeaderboardRows,
-        @JsonKey(name: "order_attribution_install_banner_dismissed")
-        String? orderAttributionInstallBannerDismissed,
-        @JsonKey(name: "homepage_layout")
-        String? homepageLayout,
-        @JsonKey(name: "homepage_stats")
-        String? homepageStats,
-        @JsonKey(name: "task_list_tracked_started_tasks")
-        String? taskListTrackedStartedTasks,
-        @JsonKey(name: "android_app_banner_dismissed")
-        String? androidAppBannerDismissed,
-        @JsonKey(name: "launch_your_store_tour_hidden")
-        String? launchYourStoreTourHidden,
-        @JsonKey(name: "coming_soon_banner_dismissed")
-        String? comingSoonBannerDismissed,
-    }) = _WoocommerceMeta;
+  const factory WoocommerceMeta({
+    @JsonKey(name: "variable_product_tour_shown")
+    String? variableProductTourShown,
+    @JsonKey(name: "activity_panel_inbox_last_read")
+    String? activityPanelInboxLastRead,
+    @JsonKey(name: "activity_panel_reviews_last_read")
+    String? activityPanelReviewsLastRead,
+    @JsonKey(name: "categories_report_columns") String? categoriesReportColumns,
+    @JsonKey(name: "coupons_report_columns") String? couponsReportColumns,
+    @JsonKey(name: "customers_report_columns") String? customersReportColumns,
+    @JsonKey(name: "orders_report_columns") String? ordersReportColumns,
+    @JsonKey(name: "products_report_columns") String? productsReportColumns,
+    @JsonKey(name: "revenue_report_columns") String? revenueReportColumns,
+    @JsonKey(name: "taxes_report_columns") String? taxesReportColumns,
+    @JsonKey(name: "variations_report_columns") String? variationsReportColumns,
+    @JsonKey(name: "dashboard_sections") String? dashboardSections,
+    @JsonKey(name: "dashboard_chart_type") String? dashboardChartType,
+    @JsonKey(name: "dashboard_chart_interval") String? dashboardChartInterval,
+    @JsonKey(name: "dashboard_leaderboard_rows")
+    String? dashboardLeaderboardRows,
+    @JsonKey(name: "order_attribution_install_banner_dismissed")
+    String? orderAttributionInstallBannerDismissed,
+    @JsonKey(name: "homepage_layout") String? homepageLayout,
+    @JsonKey(name: "homepage_stats") String? homepageStats,
+    @JsonKey(name: "task_list_tracked_started_tasks")
+    String? taskListTrackedStartedTasks,
+    @JsonKey(name: "android_app_banner_dismissed")
+    String? androidAppBannerDismissed,
+    @JsonKey(name: "launch_your_store_tour_hidden")
+    String? launchYourStoreTourHidden,
+    @JsonKey(name: "coming_soon_banner_dismissed")
+    String? comingSoonBannerDismissed,
+  }) = _WoocommerceMeta;
 
-    factory WoocommerceMeta.fromJson(Map<String, dynamic> json) => _$WoocommerceMetaFromJson(json);
+  factory WoocommerceMeta.fromJson(Map<String, dynamic> json) =>
+      _$WoocommerceMetaFromJson(json);
 }

--- a/packages/apis/lib/network/remote/woocommerce/auth/freezed_model/response/get_users_me_response.freezed.dart
+++ b/packages/apis/lib/network/remote/woocommerce/auth/freezed_model/response/get_users_me_response.freezed.dart
@@ -35,7 +35,8 @@ mixin _$GetUsersMeResponse {
   @JsonKey(name: "avatar_urls")
   AvatarUrls? get avatarUrls => throw _privateConstructorUsedError;
   @JsonKey(name: "meta")
-  List<dynamic>? get meta => throw _privateConstructorUsedError;
+  dynamic get meta =>
+      throw _privateConstructorUsedError; // Can be List or Map depending on API version
   @JsonKey(name: "is_super_admin")
   bool? get isSuperAdmin => throw _privateConstructorUsedError;
   @JsonKey(name: "woocommerce_meta")
@@ -63,7 +64,7 @@ abstract class $GetUsersMeResponseCopyWith<$Res> {
       @JsonKey(name: "link") String? link,
       @JsonKey(name: "slug") String? slug,
       @JsonKey(name: "avatar_urls") AvatarUrls? avatarUrls,
-      @JsonKey(name: "meta") List<dynamic>? meta,
+      @JsonKey(name: "meta") dynamic meta,
       @JsonKey(name: "is_super_admin") bool? isSuperAdmin,
       @JsonKey(name: "woocommerce_meta") WoocommerceMeta? woocommerceMeta,
       @JsonKey(name: "_links") Links? links});
@@ -130,7 +131,7 @@ class _$GetUsersMeResponseCopyWithImpl<$Res, $Val extends GetUsersMeResponse>
       meta: freezed == meta
           ? _value.meta
           : meta // ignore: cast_nullable_to_non_nullable
-              as List<dynamic>?,
+              as dynamic,
       isSuperAdmin: freezed == isSuperAdmin
           ? _value.isSuperAdmin
           : isSuperAdmin // ignore: cast_nullable_to_non_nullable
@@ -199,7 +200,7 @@ abstract class _$$GetUsersMeResponseImplCopyWith<$Res>
       @JsonKey(name: "link") String? link,
       @JsonKey(name: "slug") String? slug,
       @JsonKey(name: "avatar_urls") AvatarUrls? avatarUrls,
-      @JsonKey(name: "meta") List<dynamic>? meta,
+      @JsonKey(name: "meta") dynamic meta,
       @JsonKey(name: "is_super_admin") bool? isSuperAdmin,
       @JsonKey(name: "woocommerce_meta") WoocommerceMeta? woocommerceMeta,
       @JsonKey(name: "_links") Links? links});
@@ -265,9 +266,9 @@ class __$$GetUsersMeResponseImplCopyWithImpl<$Res>
           : avatarUrls // ignore: cast_nullable_to_non_nullable
               as AvatarUrls?,
       meta: freezed == meta
-          ? _value._meta
+          ? _value.meta
           : meta // ignore: cast_nullable_to_non_nullable
-              as List<dynamic>?,
+              as dynamic,
       isSuperAdmin: freezed == isSuperAdmin
           ? _value.isSuperAdmin
           : isSuperAdmin // ignore: cast_nullable_to_non_nullable
@@ -295,11 +296,10 @@ class _$GetUsersMeResponseImpl implements _GetUsersMeResponse {
       @JsonKey(name: "link") this.link,
       @JsonKey(name: "slug") this.slug,
       @JsonKey(name: "avatar_urls") this.avatarUrls,
-      @JsonKey(name: "meta") final List<dynamic>? meta,
+      @JsonKey(name: "meta") this.meta,
       @JsonKey(name: "is_super_admin") this.isSuperAdmin,
       @JsonKey(name: "woocommerce_meta") this.woocommerceMeta,
-      @JsonKey(name: "_links") this.links})
-      : _meta = meta;
+      @JsonKey(name: "_links") this.links});
 
   factory _$GetUsersMeResponseImpl.fromJson(Map<String, dynamic> json) =>
       _$$GetUsersMeResponseImplFromJson(json);
@@ -325,17 +325,10 @@ class _$GetUsersMeResponseImpl implements _GetUsersMeResponse {
   @override
   @JsonKey(name: "avatar_urls")
   final AvatarUrls? avatarUrls;
-  final List<dynamic>? _meta;
   @override
   @JsonKey(name: "meta")
-  List<dynamic>? get meta {
-    final value = _meta;
-    if (value == null) return null;
-    if (_meta is EqualUnmodifiableListView) return _meta;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(value);
-  }
-
+  final dynamic meta;
+// Can be List or Map depending on API version
   @override
   @JsonKey(name: "is_super_admin")
   final bool? isSuperAdmin;
@@ -365,7 +358,7 @@ class _$GetUsersMeResponseImpl implements _GetUsersMeResponse {
             (identical(other.slug, slug) || other.slug == slug) &&
             (identical(other.avatarUrls, avatarUrls) ||
                 other.avatarUrls == avatarUrls) &&
-            const DeepCollectionEquality().equals(other._meta, _meta) &&
+            const DeepCollectionEquality().equals(other.meta, meta) &&
             (identical(other.isSuperAdmin, isSuperAdmin) ||
                 other.isSuperAdmin == isSuperAdmin) &&
             (identical(other.woocommerceMeta, woocommerceMeta) ||
@@ -384,7 +377,7 @@ class _$GetUsersMeResponseImpl implements _GetUsersMeResponse {
       link,
       slug,
       avatarUrls,
-      const DeepCollectionEquality().hash(_meta),
+      const DeepCollectionEquality().hash(meta),
       isSuperAdmin,
       woocommerceMeta,
       links);
@@ -413,7 +406,7 @@ abstract class _GetUsersMeResponse implements GetUsersMeResponse {
       @JsonKey(name: "link") final String? link,
       @JsonKey(name: "slug") final String? slug,
       @JsonKey(name: "avatar_urls") final AvatarUrls? avatarUrls,
-      @JsonKey(name: "meta") final List<dynamic>? meta,
+      @JsonKey(name: "meta") final dynamic meta,
       @JsonKey(name: "is_super_admin") final bool? isSuperAdmin,
       @JsonKey(name: "woocommerce_meta") final WoocommerceMeta? woocommerceMeta,
       @JsonKey(name: "_links") final Links? links}) = _$GetUsersMeResponseImpl;
@@ -444,8 +437,8 @@ abstract class _GetUsersMeResponse implements GetUsersMeResponse {
   AvatarUrls? get avatarUrls;
   @override
   @JsonKey(name: "meta")
-  List<dynamic>? get meta;
-  @override
+  dynamic get meta;
+  @override // Can be List or Map depending on API version
   @JsonKey(name: "is_super_admin")
   bool? get isSuperAdmin;
   @override

--- a/packages/apis/lib/network/remote/woocommerce/auth/freezed_model/response/get_users_me_response.g.dart
+++ b/packages/apis/lib/network/remote/woocommerce/auth/freezed_model/response/get_users_me_response.g.dart
@@ -18,7 +18,7 @@ _$GetUsersMeResponseImpl _$$GetUsersMeResponseImplFromJson(
       avatarUrls: json['avatar_urls'] == null
           ? null
           : AvatarUrls.fromJson(json['avatar_urls'] as Map<String, dynamic>),
-      meta: json['meta'] as List<dynamic>?,
+      meta: json['meta'],
       isSuperAdmin: json['is_super_admin'] as bool?,
       woocommerceMeta: json['woocommerce_meta'] == null
           ? null

--- a/packages/apis/pubspec.yaml
+++ b/packages/apis/pubspec.yaml
@@ -18,8 +18,8 @@ dependencies:
     sdk: flutter
 
   # Dependency injection
-  injectable: ^2.5.1
-  get_it: 7.7.0
+  injectable: ^2.7.1
+  get_it: ^8.3.0
 
   # Networking
   retrofit: 4.1.0
@@ -38,10 +38,7 @@ dependencies:
   logger: ^2.5.0
 
   core:
-    git:
-      url: https://github.com/masterfabric-mobile/osmea.git
-      ref: dev
-      path: packages/core
+    path: ../core
 
   # Code generation and annotations
   json_annotation: ^4.9.0

--- a/packages/components/lib/src/components/tabbar/tabbar.dart
+++ b/packages/components/lib/src/components/tabbar/tabbar.dart
@@ -288,7 +288,7 @@ class OsmeaTabBar extends CoreTabBarContainer {
 
   /// 🎯 Build individual tab widgets
   List<Widget> _buildTabWidgets(BuildContext context, TabBarState state) {
-    return tabs.asMap().entries.map((entry) {
+    final tabWidgets = tabs.asMap().entries.map((entry) {
       final index = entry.key;
       final tab = entry.value;
       final isActive =
@@ -301,6 +301,17 @@ class OsmeaTabBar extends CoreTabBarContainer {
         state,
       );
     }).toList();
+
+    // For fixed style, wrap tabs in Expanded to ensure equal width distribution
+    if (style == TabBarStyle.fixed && position.isHorizontal) {
+      return tabWidgets
+          .map((tab) => Expanded(
+                child: tab,
+              ))
+          .toList();
+    }
+
+    return tabWidgets;
   }
 
   /// 🎯 Build individual tab widget
@@ -314,15 +325,33 @@ class OsmeaTabBar extends CoreTabBarContainer {
     final effectiveTextColor = _getEffectiveTextColor(context, isActive);
     final effectiveIconColor = _getEffectiveIconColor(context, isActive);
 
+    // Adjust padding based on variant - minimal horizontal padding, keep vertical
+    // For secondary variant, use minimal horizontal padding to reduce row width
+    final tabPadding = variant == TabBarVariant.secondary
+        ? const EdgeInsets.symmetric(horizontal: 0, vertical: 20)
+        : const EdgeInsets.symmetric(horizontal: 16, vertical: 12);
+
+    // Adjust border radius based on variant - must match container for seamless look
+    final tabBorderRadius = variant == TabBarVariant.secondary
+        ? BorderRadius.circular(10)
+        : BorderRadius.circular(13);
+
+    // For secondary variant with fixed style, remove constraints to allow equal expansion
+    // Also ensure width fills available space
+    final tabConstraints =
+        (variant == TabBarVariant.secondary && style == TabBarStyle.fixed)
+            ? null
+            : _getTabConstraints(context);
+
     Widget tabContent = OsmeaContainer(
-      padding: const EdgeInsets.symmetric(
-        horizontal: 8,
-        vertical: 8,
-      ),
-      constraints: _getTabConstraints(context),
+      padding: tabPadding,
+      constraints: tabConstraints,
+      width: (variant == TabBarVariant.secondary && style == TabBarStyle.fixed)
+          ? double.infinity
+          : null,
       decoration: BoxDecoration(
         color: _getTabBackgroundColor(context, isActive),
-        borderRadius: BorderRadius.circular(13),
+        borderRadius: tabBorderRadius,
       ),
       child: _buildTabContent(
         context,
@@ -462,22 +491,19 @@ class OsmeaTabBar extends CoreTabBarContainer {
 
     // Add text if should show labels
     if (showLabels) {
-      Widget textWidget = ConstrainedBox(
-        constraints: const BoxConstraints(maxWidth: 100), // Prevent overflow
-        child: OsmeaText(
-          tab.text,
-          style: TextStyle(
-            fontSize: 12, // Smaller for mobile
-            fontWeight: isActive ? FontWeight.w500 : FontWeight.w400,
-            color: textColor,
-            height: 1.1,
-            letterSpacing: 0.05,
-          ),
-          maxLines: 1,
-          overflow: TextOverflow.ellipsis,
-          textAlign: TextAlign.center,
-          softWrap: false,
+      Widget textWidget = OsmeaText(
+        tab.text,
+        style: TextStyle(
+          fontSize: variant == TabBarVariant.secondary ? 14 : 13,
+          fontWeight: isActive ? FontWeight.w600 : FontWeight.w400,
+          color: textColor,
+          height: 1.3,
+          letterSpacing: variant == TabBarVariant.secondary ? 0.0 : 0.1,
         ),
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+        textAlign: TextAlign.center,
+        softWrap: false,
       );
 
       children.add(textWidget);
@@ -504,44 +530,38 @@ class OsmeaTabBar extends CoreTabBarContainer {
         mainAxisSize: MainAxisSize.min,
         mainAxisAlignment: MainAxisAlignment.center,
         crossAxisAlignment: CrossAxisAlignment.center,
-        children: children
-            .map(
-              (child) => Padding(
-                padding:
-                    EdgeInsets.symmetric(vertical: children.length > 1 ? 1 : 0),
-                child: child,
-              ),
-            )
-            .toList(),
+        children: children,
       );
     } else {
+      // For horizontal layout, wrap text in Expanded if both icon and text exist
+      if (children.length > 1 && showLabels && showIcons && tab.icon != null) {
+        return Row(
+          mainAxisSize: MainAxisSize.max,
+          mainAxisAlignment: MainAxisAlignment.center,
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            children[0], // Icon
+            SizedBox(width: variant == TabBarVariant.secondary ? 4 : 8),
+            Expanded(child: children[1]), // Text with expansion
+          ],
+        );
+      }
+
+      // For text only, center it properly and allow expansion
       return Row(
-        mainAxisSize: MainAxisSize.min,
+        mainAxisSize: MainAxisSize.max,
         mainAxisAlignment: MainAxisAlignment.center,
         crossAxisAlignment: CrossAxisAlignment.center,
-        children: children
-            .map(
-              (child) => Flexible(
-                child: Padding(
-                  padding: EdgeInsets.symmetric(
-                      horizontal: children.length > 1 ? 2 : 0),
-                  child: child,
-                ),
-              ),
-            )
-            .toList(),
+        children: children.map((child) => Expanded(child: child)).toList(),
       );
     }
   }
 
   /// 🎨 Get tab background color based on indicator style
   Color _getTabBackgroundColor(BuildContext context, bool isActive) {
-    // For line, dot, and none indicators, keep tabs transparent
-    if (indicatorStyle == TabBarIndicatorStyle.line ||
-        indicatorStyle == TabBarIndicatorStyle.dot ||
-        indicatorStyle == TabBarIndicatorStyle.none ||
-        indicatorStyle == TabBarIndicatorStyle.border) {
-      return OsmeaColors.transparent;
+    // For secondary variant, always show active tab with white background for segmented control look
+    if (variant == TabBarVariant.secondary && isActive) {
+      return activeFillColor ?? OsmeaColors.white;
     }
 
     // For fill indicator, use custom fill color or default indicator color
@@ -549,6 +569,14 @@ class OsmeaTabBar extends CoreTabBarContainer {
       if (isActive) {
         return activeFillColor ?? getEffectiveIndicatorColor(context);
       }
+      return OsmeaColors.transparent;
+    }
+
+    // For line, dot, border, and none indicators, keep tabs transparent (except secondary variant active tabs)
+    if (indicatorStyle == TabBarIndicatorStyle.line ||
+        indicatorStyle == TabBarIndicatorStyle.dot ||
+        indicatorStyle == TabBarIndicatorStyle.none ||
+        indicatorStyle == TabBarIndicatorStyle.border) {
       return OsmeaColors.transparent;
     }
 
@@ -614,11 +642,13 @@ class OsmeaTabBar extends CoreTabBarContainer {
   }
 
   /// 📐 Get tab constraints
-  BoxConstraints _getTabConstraints(BuildContext context) {
-    final screenWidth = MediaQuery.of(context).size.width;
+  BoxConstraints? _getTabConstraints(BuildContext context) {
+    // For secondary variant with fixed style, don't use constraints (let Expanded handle it)
+    if (variant == TabBarVariant.secondary && style == TabBarStyle.fixed) {
+      return null;
+    }
 
-    // Mobile-friendly calculations
-    final tabCount = tabs.length;
+    final screenWidth = MediaQuery.of(context).size.width;
 
     switch (position) {
       case TabBarPosition.top:
@@ -632,14 +662,9 @@ class OsmeaTabBar extends CoreTabBarContainer {
             maxHeight: 60,
           );
         } else {
-          // Fixed tabs need to fit in screen
-          final availableWidth = screenWidth - 32; // Account for padding
-          final maxTabWidth =
-              (availableWidth / tabCount) - 8; // Account for spacing
-
-          return BoxConstraints(
-            minWidth: 60,
-            maxWidth: math.max(maxTabWidth, 60),
+          // Fixed tabs should expand equally - constraints will be handled by Expanded widget
+          return const BoxConstraints(
+            minWidth: 80,
             minHeight: 44,
             maxHeight: 56,
           );

--- a/packages/components/lib/src/core/tabbar_container_widget.dart
+++ b/packages/components/lib/src/core/tabbar_container_widget.dart
@@ -4,7 +4,6 @@ import 'package:flutter/material.dart';
 import 'package:osmea_components/osmea_components.dart';
 import 'package:osmea_components/src/core/container_widget.dart';
 
-
 /// 📑 **OSMEA Core TabBar Container**
 ///
 /// Copyright (c) 2025, OSMEA Team
@@ -119,14 +118,15 @@ abstract class CoreTabBarContainer extends CoreContainer {
   /// 🎯 Get effective background color based on variant
   Color? getEffectiveBackgroundColor(BuildContext context) {
     if (backgroundColor != null) return backgroundColor;
-    
+
     final colorScheme = Theme.of(context).colorScheme;
-    
+
     switch (variant) {
       case TabBarVariant.primary:
         return colorScheme.primary;
       case TabBarVariant.secondary:
-        return colorScheme.surface;
+        // Use a light gray background for segmented control look
+        return OsmeaColors.ash;
       case TabBarVariant.outlined:
         return OsmeaColors.transparent;
       case TabBarVariant.glass:
@@ -139,9 +139,9 @@ abstract class CoreTabBarContainer extends CoreContainer {
   /// 🔲 Get effective border color based on variant
   Color? getEffectiveBorderColor(BuildContext context) {
     if (borderColor != null) return borderColor;
-    
+
     final colorScheme = Theme.of(context).colorScheme;
-    
+
     switch (variant) {
       case TabBarVariant.outlined:
         return colorScheme.outline;
@@ -152,13 +152,12 @@ abstract class CoreTabBarContainer extends CoreContainer {
     }
   }
 
-
   /// 📊 Get effective indicator color based on variant
   Color getEffectiveIndicatorColor(BuildContext context) {
     if (indicatorColor != null) return indicatorColor!;
-    
+
     final colorScheme = Theme.of(context).colorScheme;
-    
+
     switch (variant) {
       case TabBarVariant.primary:
         return colorScheme.onPrimary;
@@ -174,7 +173,7 @@ abstract class CoreTabBarContainer extends CoreContainer {
   /// ⭕ Get effective border radius based on size and position
   BorderRadius getEffectiveBorderRadius(BuildContext context) {
     if (borderRadius != null) return borderRadius!;
-    
+
     // Different radius based on position
     switch (position) {
       case TabBarPosition.top:
@@ -193,7 +192,7 @@ abstract class CoreTabBarContainer extends CoreContainer {
   /// ✨ Get effective elevation based on variant
   double getEffectiveElevation(BuildContext context) {
     if (elevation != null) return elevation!;
-    
+
     switch (variant) {
       case TabBarVariant.primary:
         return 2.0;
@@ -208,10 +207,12 @@ abstract class CoreTabBarContainer extends CoreContainer {
   }
 
   /// 🪟 Check if variant needs backdrop blur
-  bool get needsBackdropBlur => variant == TabBarVariant.glass && enableGlassEffect;
+  bool get needsBackdropBlur =>
+      variant == TabBarVariant.glass && enableGlassEffect;
 
   /// 🔲 Check if variant needs border
-  bool get needsBorder => variant == TabBarVariant.outlined || variant == TabBarVariant.glass;
+  bool get needsBorder =>
+      variant == TabBarVariant.outlined || variant == TabBarVariant.glass;
 
   /// 📊 Check if indicator should be shown
   bool get shouldShowIndicator => indicatorStyle != TabBarIndicatorStyle.none;
@@ -219,9 +220,9 @@ abstract class CoreTabBarContainer extends CoreContainer {
   /// 📐 Get container constraints based on position and size
   BoxConstraints getEffectiveConstraints(BuildContext context) {
     if (constraints != null) return constraints!;
-    
+
     final screenSize = MediaQuery.of(context).size;
-    
+
     switch (position) {
       case TabBarPosition.top:
       case TabBarPosition.bottom:
@@ -229,9 +230,9 @@ abstract class CoreTabBarContainer extends CoreContainer {
           minHeight: 64,
           maxHeight: 80,
           minWidth: 0,
-          maxWidth: math.min(screenSize.width - 16, 400), // Limit width for mobile
+          maxWidth:
+              math.min(screenSize.width - 16, 400), // Limit width for mobile
         );
-
     }
   }
 
@@ -240,13 +241,32 @@ abstract class CoreTabBarContainer extends CoreContainer {
     final effectiveBackgroundColor = getEffectiveBackgroundColor(context);
     final effectiveBorderColor = getEffectiveBorderColor(context);
 
+    // Adjust border radius for secondary variant (segmented control style)
+    // Container radius should be slightly larger than tab radius for visual harmony
+    final containerRadius = variant == TabBarVariant.secondary
+        ? BorderRadius.circular(12)
+        : BorderRadius.circular(13);
+
     return BoxDecoration(
       color: effectiveBackgroundColor ?? OsmeaColors.snow,
-      borderRadius: BorderRadius.circular(13),
-      border: needsBorder && effectiveBorderColor != null 
+      borderRadius: containerRadius,
+      border: needsBorder && effectiveBorderColor != null
           ? Border.all(color: effectiveBorderColor, width: 1.0)
           : null,
     );
+  }
+
+  /// 📐 Get effective padding based on variant
+  EdgeInsetsGeometry? getEffectivePadding(BuildContext context) {
+    if (padding != null) return padding;
+
+    // For secondary variant, use minimal equal padding for clean look
+    if (variant == TabBarVariant.secondary) {
+      return const EdgeInsets.all(2.0);
+    }
+
+    // Default padding for other variants
+    return const EdgeInsets.symmetric(horizontal: 8.0, vertical: 8.0);
   }
 
   @override
@@ -254,7 +274,7 @@ abstract class CoreTabBarContainer extends CoreContainer {
     Widget container = OsmeaComponents.container(
       key: key,
       alignment: alignment,
-      padding: padding,
+      padding: getEffectivePadding(context),
       decoration: decoration ?? buildTabBarDecoration(context),
       foregroundDecoration: foregroundDecoration,
       width: width,
@@ -280,4 +300,4 @@ abstract class CoreTabBarContainer extends CoreContainer {
 
     return container;
   }
-} 
+}

--- a/packages/components/lib/src/core/tabbar_row_widget.dart
+++ b/packages/components/lib/src/core/tabbar_row_widget.dart
@@ -5,7 +5,6 @@ import 'package:osmea_components/src/components/row/row.dart';
 import 'package:osmea_components/src/components/wrap/wrap.dart';
 import 'package:osmea_components/src/core/row_widget.dart';
 
-
 /// 📑 **OSMEA Core TabBar Row**
 ///
 /// Copyright (c) 2025, OSMEA Team
@@ -121,8 +120,8 @@ abstract class CoreTabBarRow extends CoreRow {
     // Use style-based alignment if no custom alignment specified
     switch (style) {
       case TabBarStyle.fixed:
-        return position.isHorizontal 
-            ? MainAxisAlignment.spaceEvenly 
+        return position.isHorizontal
+            ? MainAxisAlignment.spaceEvenly
             : MainAxisAlignment.start;
       case TabBarStyle.scrollable:
         return MainAxisAlignment.start;
@@ -161,15 +160,20 @@ abstract class CoreTabBarRow extends CoreRow {
   /// ↔️ Get effective spacing between tabs
   double getEffectiveSpacing(BuildContext context) {
     if (spacing != null) return spacing!;
-    
-    // TDesign style minimal spacing
+
+    // For secondary variant, no spacing between tabs (segmented control style)
+    if (variant == TabBarVariant.secondary) {
+      return 0.0;
+    }
+
+    // TDesign style minimal spacing for other variants
     return 4.0;
   }
 
   /// ↕️ Get effective run spacing for wrapped tabs
   double getEffectiveRunSpacing(BuildContext context) {
     if (runSpacing != null) return runSpacing!;
-    
+
     final sizeConfig = size.config(context);
     return sizeConfig.tabSpacing * 0.5;
   }
@@ -177,14 +181,14 @@ abstract class CoreTabBarRow extends CoreRow {
   /// ⏱️ Get effective animation duration
   Duration getEffectiveAnimationDuration(BuildContext context) {
     if (animationDuration != null) return animationDuration!;
-    
+
     return const Duration(milliseconds: 200);
   }
 
   /// 🎮 Get effective scroll physics
   ScrollPhysics getEffectiveScrollPhysics(BuildContext context) {
     if (physics != null) return physics!;
-    
+
     switch (style) {
       case TabBarStyle.scrollable:
         return const BouncingScrollPhysics();
@@ -196,7 +200,7 @@ abstract class CoreTabBarRow extends CoreRow {
   /// 🔄 Get text direction based on position
   TextDirection? getEffectiveTextDirection(BuildContext context) {
     if (textDirection != null) return textDirection;
-    
+
     return Directionality.of(context);
   }
 
@@ -224,13 +228,13 @@ abstract class CoreTabBarRow extends CoreRow {
   /// 🎯 Build tabs with proper spacing
   List<Widget> buildTabsWithSpacing(BuildContext context, List<Widget> tabs) {
     if (tabs.isEmpty) return tabs;
-    
+
     final effectiveSpacing = getEffectiveSpacing(context);
     final spacedTabs = <Widget>[];
-    
+
     for (int i = 0; i < tabs.length; i++) {
       spacedTabs.add(tabs[i]);
-      
+
       // Add spacing between tabs (except after last tab)
       if (i < tabs.length - 1) {
         if (axis == Axis.horizontal) {
@@ -240,7 +244,7 @@ abstract class CoreTabBarRow extends CoreRow {
         }
       }
     }
-    
+
     return spacedTabs;
   }
 
@@ -249,7 +253,7 @@ abstract class CoreTabBarRow extends CoreRow {
     if (!shouldScroll) {
       return child;
     }
-    
+
     return SingleChildScrollView(
       controller: scrollController,
       physics: getEffectiveScrollPhysics(context),
@@ -262,7 +266,7 @@ abstract class CoreTabBarRow extends CoreRow {
   /// ⚡ Build animated wrapper if needed
   Widget buildAnimatedWrapper(BuildContext context, Widget child) {
     if (!shouldAnimate) return child;
-    
+
     return AnimatedContainer(
       duration: getEffectiveAnimationDuration(context),
       curve: easeInOut,
@@ -277,12 +281,12 @@ abstract class CoreTabBarRow extends CoreRow {
     final effectiveMainAxisSize = getEffectiveMainAxisSize();
     final effectiveCrossAxisAlignment = getEffectiveCrossAxisAlignment();
     final effectiveTextDirection = getEffectiveTextDirection(context);
-    
+
     // Build tabs with spacing
     final spacedChildren = buildTabsWithSpacing(context, children);
-    
+
     Widget rowWidget;
-    
+
     // Build based on position (horizontal or vertical)
     if (position.isHorizontal) {
       // For horizontal tabs, use better overflow protection
@@ -297,9 +301,15 @@ abstract class CoreTabBarRow extends CoreRow {
           children: children,
         );
       } else {
+        // For secondary variant with fixed style, use start alignment since tabs are already Expanded
+        final finalMainAxisAlignment =
+            (variant == TabBarVariant.secondary && style == TabBarStyle.fixed)
+                ? MainAxisAlignment.start
+                : effectiveMainAxisAlignment;
+
         rowWidget = OsmeaRow(
-          mainAxisAlignment: effectiveMainAxisAlignment,
-          mainAxisSize: effectiveMainAxisSize,
+          mainAxisAlignment: finalMainAxisAlignment,
+          mainAxisSize: MainAxisSize.max,
           crossAxisAlignment: effectiveCrossAxisAlignment,
           textDirection: effectiveTextDirection,
           verticalDirection: verticalDirection,
@@ -331,13 +341,13 @@ abstract class CoreTabBarRow extends CoreRow {
         );
       }
     }
-    
+
     // Apply scrollable wrapper if needed
     rowWidget = buildScrollableWrapper(context, rowWidget);
-    
+
     // Apply animated wrapper if needed
     rowWidget = buildAnimatedWrapper(context, rowWidget);
-    
+
     return rowWidget;
   }
-} 
+}

--- a/packages/core/lib/src/di/config/config_di.config.dart
+++ b/packages/core/lib/src/di/config/config_di.config.dart
@@ -45,6 +45,7 @@ extension GetItInjectableX on _i174.GetIt {
     );
     final commonLoggerModule = _$CommonLoggerModule();
     gh.factory<_i674.CommonLogger>(() => commonLoggerModule.commonLogger);
+    gh.factory<_i111.AccountCubit>(() => _i111.AccountCubit());
     gh.factory<_i651.AuthCubit>(() => _i651.AuthCubit());
     gh.factory<_i905.EmptyViewCubit>(() => _i905.EmptyViewCubit());
     gh.factory<_i183.ErrorHandlingCubit>(() => _i183.ErrorHandlingCubit());
@@ -58,8 +59,6 @@ extension GetItInjectableX on _i174.GetIt {
     gh.singleton<_i974.Logger>(() => commonLoggerModule.logger);
     gh.singleton<_i481.ICommonLogger>(
         () => _i674.CommonLogger(logger: gh<_i974.Logger>()));
-    gh.factory<_i111.AccountCubit>(() =>
-        _i111.AccountCubit(getUsersMeCallback: gh<_i111.GetUsersMeCallback>()));
     return this;
   }
 }

--- a/packages/core/lib/src/views/account/cubit/account_cubit.dart
+++ b/packages/core/lib/src/views/account/cubit/account_cubit.dart
@@ -19,30 +19,22 @@ import 'package:core/src/helper/auth_storage_helper.dart';
 import 'package:core/src/views/account/cubit/account_state.dart';
 import 'package:injectable/injectable.dart';
 
-/// Typedef for getUsersMe callback function
-/// This allows injectable to properly resolve the function type
-typedef GetUsersMeCallback = Future<Map<String, dynamic>?> Function();
-
 /// 🧠 **OSMEA Account Cubit**
 ///
 /// Manages account view state and data loading
 /// Supports loading from app_config.json or mock data fallback
-/// 
+///
 /// Note: This cubit is platform-agnostic and only uses AuthStorageHelper
 /// for user data. It does not depend on AuthCubit to maintain core package independence.
+/// Platform-specific implementations should provide user data (username, email, etc.) directly.
 @injectable
 class AccountCubit extends BaseViewModelCubit<AccountState> {
-  AccountCubit({
-    GetUsersMeCallback? getUsersMeCallback,
-  }) : super(const AccountState()) {
-    _getUsersMeCallback = getUsersMeCallback;
+  AccountCubit() : super(const AccountState()) {
     debugPrint('🔍 AccountCubit: Constructor called');
-    debugPrint(
-        '🔍 AccountCubit: getUsersMeCallback is null: ${getUsersMeCallback == null}');
   }
 
   final AssetConfigHelper _configHelper = AssetConfigHelper();
-  GetUsersMeCallback? _getUsersMeCallback;
+  Map<String, dynamic>? _userApiData;
 
   // Public trigger functions
   void initialize() => _initialize();
@@ -50,6 +42,14 @@ class AccountCubit extends BaseViewModelCubit<AccountState> {
   /// Refresh profile data from auth storage
   /// Call this when user logs in or profile is updated
   void refreshProfile() => _initialize();
+
+  /// Set user API data (username, email, etc.)
+  /// Platform-specific implementations should call this with API response data
+  void setUserApiData(Map<String, dynamic>? userData) {
+    _userApiData = userData;
+    debugPrint('👤 AccountCubit: User API data set');
+    debugPrint('👤 AccountCubit: User data keys: ${userData?.keys.toList()}');
+  }
 
   // Private methods
   Future<void> _initialize() async {
@@ -83,8 +83,8 @@ class AccountCubit extends BaseViewModelCubit<AccountState> {
         accountData = _getMockAccountData();
       }
 
-      // Load profile data: Priority 1) Auth Storage, 2) Config, 3) Default
-      final profileData = await _loadProfileData(accountData);
+      // Load profile data: Priority 1) User API Data, 2) Auth Storage, 3) Config, 4) Default
+      final profileData = await _loadProfileData(accountData, _userApiData);
 
       // Parse sections
       final sectionsList = accountData['sections'];
@@ -118,56 +118,36 @@ class AccountCubit extends BaseViewModelCubit<AccountState> {
     }
   }
 
-  /// Load profile data: Always try Auth Storage first, then use default values
-  /// Config is not used for profile data - it's always from auth storage or default
-  /// Also checks AuthCubit metadata for getUsersMe data
-  Future<AccountProfileData> _loadProfileData(
-      Map<String, dynamic> accountData) async {
+  /// Load profile data: Priority 1) User API Data, 2) Auth Storage, 3) Default
+  /// Config is not used for profile data - it's always from user API data, auth storage or default
+  /// Platform-specific implementations should provide user API data via setUserApiData()
+  Future<AccountProfileData> _loadProfileData(Map<String, dynamic> accountData,
+      Map<String, dynamic>? userApiData) async {
     try {
       // Always try to load from Auth Storage first
       final authStorage = AuthStorageHelper();
       final userData = await authStorage.getUserData();
 
-      // Call getUsersMe API to get fresh user data (user can update their info)
-      // Use callback if provided, otherwise fallback to metadata
-      Map<String, dynamic>? getUsersMeData;
-      if (_getUsersMeCallback != null) {
-        try {
-          debugPrint(
-              '👤 AccountCubit: Calling getUsersMe API for fresh user data...');
-          getUsersMeData = await _getUsersMeCallback!();
-          if (getUsersMeData != null) {
-            final apiName = getUsersMeData['name'];
-            debugPrint('✅ AccountCubit: getUsersMe API call successful');
-            debugPrint(
-                '👤 AccountCubit: getUsersMeData keys: ${getUsersMeData.keys.toList()}');
-            debugPrint(
-                '👤 AccountCubit: User name from API: "$apiName" (type: ${apiName.runtimeType})');
+      // Use user API data if provided (from platform-specific implementation)
+      Map<String, dynamic>? getUsersMeData = userApiData;
+      if (getUsersMeData != null) {
+        final apiName = getUsersMeData['name'];
+        debugPrint('✅ AccountCubit: User API data available');
+        debugPrint(
+            '👤 AccountCubit: User API data keys: ${getUsersMeData.keys.toList()}');
+        debugPrint(
+            '👤 AccountCubit: User name from API: "$apiName" (type: ${apiName.runtimeType})');
 
-            // Check if name is valid (not null and not empty)
-            if (apiName != null && apiName is String && apiName.isNotEmpty) {
-              debugPrint(
-                  '✅ AccountCubit: Valid name found in API response: "$apiName"');
-            } else {
-              debugPrint(
-                  '⚠️ AccountCubit: Name is null or empty in API response');
-              // Don't set to null, keep the data but name will be null
-            }
-          } else {
-            debugPrint('⚠️ AccountCubit: getUsersMe API returned null');
-            getUsersMeData = null;
-          }
-        } catch (e, stackTrace) {
-          debugPrint('⚠️ AccountCubit: Error calling getUsersMe API: $e');
-          debugPrint('⚠️ AccountCubit: Stack trace: $stackTrace');
-          getUsersMeData = null;
+        // Check if name is valid (not null and not empty)
+        if (apiName != null && apiName is String && apiName.isNotEmpty) {
+          debugPrint(
+              '✅ AccountCubit: Valid name found in API response: "$apiName"');
+        } else {
+          debugPrint('⚠️ AccountCubit: Name is null or empty in API response');
         }
       } else {
-        debugPrint('⚠️ AccountCubit: getUsersMe callback is null');
+        debugPrint('⚠️ AccountCubit: User API data not provided');
       }
-
-      // Note: Metadata fallback removed - AccountCubit should not depend on AuthCubit
-      // Platform-specific implementations can provide getUsersMeCallback if needed
 
       if (userData != null && userData.isNotEmpty) {
         debugPrint('👤 AccountCubit: Loading profile from auth storage');
@@ -430,5 +410,31 @@ class AccountCubit extends BaseViewModelCubit<AccountState> {
     debugPrint('🗑️ AccountCubit: Clearing account data...');
     stateChanger(const AccountState());
     debugPrint('✅ AccountCubit: Account data cleared');
+  }
+
+  /// Sign out from account
+  /// Clears all account-related data and state
+  /// Platform-specific cleanup (e.g., AuthCubit signOut) can be provided via callback
+  Future<void> signOut({Future<void> Function()? onSignOut}) async {
+    debugPrint('🚪 AccountCubit: Signing out...');
+
+    // Clear user API data
+    _userApiData = null;
+    debugPrint('✅ AccountCubit: User API data cleared');
+
+    // Clear account state
+    clearAccountData();
+
+    // Call platform-specific signOut callback if provided
+    if (onSignOut != null) {
+      try {
+        await onSignOut();
+        debugPrint('✅ AccountCubit: Platform-specific signOut completed');
+      } catch (e) {
+        debugPrint('⚠️ AccountCubit: Error in platform-specific signOut: $e');
+      }
+    }
+
+    debugPrint('✅ AccountCubit: Sign out completed');
   }
 }

--- a/packages/core/pubspec.yaml
+++ b/packages/core/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   hydrated_bloc: ^10.1.1 # Persisted state management for Cubit/BLoC (bloc 9.x)
   equatable: ^2.0.7 # Value equality
   go_router: ^15.1.1 # Routing
-  injectable: ^2.5.1 # Dependency injection
+  injectable: ^2.7.1 # Dependency injection
   logger: ^2.5.0 # Logging utility
   slang: ^4.11.1
   url_launcher: ^6.3.1 # URL launcher for support links
@@ -33,7 +33,7 @@ dependencies:
   firebase_remote_config: ^5.3.4 # Remote Config
   device_info_plus: ^11.4.0 # Device info
   package_info_plus: ^8.3.0 # Package info
-  dio: ^5.4.3 # HTTP client for file downloads
+  dio: ^5.7.0 # HTTP client for file downloads
   path_provider: ^2.1.5 # Path provider for file storage
   permission_handler: ^11.2.0 # Runtime permissions handler
   share_plus: ^10.1.4 # Sharing text/files across platforms
@@ -52,7 +52,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   build_runner: ^2.4.7 # Code generation
-  injectable_generator: ^2.6.2 # Injectable code generator
+  injectable_generator: ^2.11.1 # Injectable code generator
   slang_build_runner: ^4.8.0
  
 dependency_overrides:

--- a/projects/storefront_woo/lib/app/core/config/config_di.dart
+++ b/projects/storefront_woo/lib/app/core/config/config_di.dart
@@ -5,7 +5,6 @@ import 'package:injectable/injectable.dart';
 import 'package:storefront_woo/app/core/config/config_di.config.dart';
 import 'package:storefront_woo/app/views/view_wishlist/models/wishlist_view_model.dart';
 import 'package:flutter/foundation.dart';
-import 'package:apis/network/remote/woocommerce/auth/abstract/woo_auth_service.dart';
 
 GetIt getIt = GetIt.instance;
 
@@ -14,11 +13,13 @@ Future<GetIt> configureDependencies({String? environment}) async {
   try {
     debugPrint('🔧 Configuring dependencies for environment: $environment');
 
-    // Initialize core dependencies
+    // Initialize core dependencies FIRST (Logger is registered here)
+    // APIs package needs Logger which is registered in core
     getIt = await Core().init(getIt);
     debugPrint('✅ Core dependencies initialized');
 
-    // Initialize APIs package dependencies
+    // Initialize APIs package dependencies AFTER core
+    // WooNetwork.init() calls configureDependencies which needs Logger
     await _initializeApisPackage(environment);
     debugPrint('✅ APIs package dependencies initialized');
 
@@ -39,86 +40,6 @@ Future<GetIt> configureDependencies({String? environment}) async {
     } catch (e) {
       debugPrint('⚠️ Could not register WishlistViewModel as singleton: $e');
       // Continue - factory registration will be used
-    }
-
-    // Override AccountCubit to inject getUsersMe callback for fresh API calls
-    // This ensures profile data is always fresh (user can update their info)
-    try {
-      debugPrint('🔍 storefront_woo DI: Checking AccountCubit registration...');
-      debugPrint('🔍 storefront_woo DI: AccountCubit isRegistered: ${getIt.isRegistered<AccountCubit>()}');
-      if (getIt.isRegistered<AccountCubit>()) {
-        debugPrint('🔍 storefront_woo DI: Unregistering existing AccountCubit...');
-        getIt.unregister<AccountCubit>();
-        debugPrint('✅ storefront_woo DI: AccountCubit unregistered');
-      }
-      debugPrint('🔍 storefront_woo DI: Registering AccountCubit with getUsersMe callback...');
-      getIt.registerFactory<AccountCubit>(() {
-        debugPrint('🔍 storefront_woo DI: AccountCubit factory called');
-        // Try to get AuthCubit from GetIt if registered
-        AuthCubit? authCubit;
-        try {
-          if (getIt.isRegistered<AuthCubit>()) {
-            authCubit = getIt<AuthCubit>();
-            debugPrint('✅ storefront_woo DI: AuthCubit found');
-          } else {
-            debugPrint('⚠️ storefront_woo DI: AuthCubit not registered');
-          }
-        } catch (e) {
-          debugPrint('⚠️ AccountCubit DI: AuthCubit not available: $e');
-        }
-
-        // Create getUsersMe callback that calls API directly
-        // IMPORTANT: Return name as-is from API, do NOT process it
-        Future<Map<String, dynamic>?> getUsersMeCallback() async {
-          try {
-            debugPrint('🔍 AccountCubit DI: getUsersMe callback called');
-            final jwtToken = await WooJwtTokenStorage.loadToken();
-            if (jwtToken != null && jwtToken.accessToken.isNotEmpty) {
-              debugPrint('🔍 AccountCubit DI: JWT token found, calling API...');
-              final authService = getIt<WooAuthService>();
-              final authHeader = 'Bearer ${jwtToken.accessToken}';
-              final userMeResponse = await authService.getUsersMe(authHeader);
-              
-              debugPrint('✅ AccountCubit DI: getUsersMe API call successful');
-              debugPrint('👤 AccountCubit DI: User name from API (raw): "${userMeResponse.name}"');
-              debugPrint('👤 AccountCubit DI: User name type: ${userMeResponse.name.runtimeType}');
-              
-              // Return name as-is from API response - NO processing
-              final result = {
-                'id': userMeResponse.id,
-                'name': userMeResponse.name, // Use name directly, no processing
-                'url': userMeResponse.url,
-                'description': userMeResponse.description,
-                'link': userMeResponse.link,
-                'slug': userMeResponse.slug,
-                'avatar_urls': userMeResponse.avatarUrls?.toJson(),
-                'is_super_admin': userMeResponse.isSuperAdmin,
-                'woocommerce_meta': userMeResponse.woocommerceMeta?.toJson(),
-              };
-              
-              debugPrint('👤 AccountCubit DI: Returning result with name: "${result['name']}"');
-              return result;
-            } else {
-              debugPrint('⚠️ AccountCubit DI: No JWT token found');
-            }
-          } catch (e, stackTrace) {
-            debugPrint('⚠️ AccountCubit DI: Error calling getUsersMe API: $e');
-            debugPrint('⚠️ AccountCubit DI: Stack trace: $stackTrace');
-          }
-          return null;
-        }
-
-        debugPrint('🔍 storefront_woo DI: Creating AccountCubit with callback...');
-        final accountCubit = AccountCubit(
-          getUsersMeCallback: getUsersMeCallback,
-        );
-        debugPrint('✅ storefront_woo DI: AccountCubit created with callback');
-        return accountCubit;
-      });
-      debugPrint('✅ AccountCubit registered with getUsersMe callback in storefront_woo DI');
-    } catch (e) {
-      debugPrint('⚠️ Could not register AccountCubit with callback: $e');
-      // Continue - core registration will be used
     }
 
     return result;

--- a/projects/storefront_woo/lib/app/routes/app_routes.dart
+++ b/projects/storefront_woo/lib/app/routes/app_routes.dart
@@ -29,9 +29,7 @@ final GoRouter appRouter = GoRouter(
       builder: (BuildContext context, GoRouterState state, Widget child) {
         return Scaffold(
           body: child,
-          bottomNavigationBar: _getNavbarForRoute(
-            state.uri.path,
-          ),
+          bottomNavigationBar: _getNavbarForRoute(state.uri.path),
         );
       },
       routes: [
@@ -617,6 +615,10 @@ final GoRouter appRouter = GoRouter(
         final accountCubit = GetIt.I<AccountCubit>();
         final authCubit = GetIt.I<AuthCubit>();
 
+        // Load user API data and set it to AccountCubit
+        // This ensures profile data is always fresh (user can update their info)
+        _loadUserApiData(accountCubit);
+
         return CustomTransitionPage(
           child: BlocListener<AuthCubit, AuthState>(
             bloc: authCubit,
@@ -627,6 +629,8 @@ final GoRouter appRouter = GoRouter(
                   '👤 Route: AuthCubit authenticated, refreshing profile...',
                 );
                 WidgetsBinding.instance.addPostFrameCallback((_) {
+                  // Reload user API data and refresh profile
+                  _loadUserApiData(accountCubit);
                   accountCubit.refreshProfile();
                 });
               }
@@ -653,45 +657,63 @@ final GoRouter appRouter = GoRouter(
                 }
               },
               onSignOut: () async {
-                // Platform-specific cleanup: cookies, wishlist, cart tokens
-                debugPrint('🚪 Route: Starting platform-specific cleanup...');
+                // AccountCubit handles its own state clearing
+                // Platform-specific cleanup is provided via callback
+                await accountCubit.signOut(
+                  onSignOut: () async {
+                    // Platform-specific cleanup: cookies, wishlist, cart tokens, AuthCubit
+                    debugPrint(
+                      '🚪 Route: Starting platform-specific cleanup...',
+                    );
 
-                // Step 1: Clear WooCommerce JWT token
-                try {
-                  await WooJwtTokenStorage.clearToken();
-                  debugPrint('✅ Route: WooJWT token cleared');
-                } catch (e) {
-                  debugPrint('⚠️ Route: Failed to clear WooJWT token: $e');
-                }
+                    // Step 1: Sign out from AuthCubit
+                    try {
+                      await authCubit.signOut();
+                      debugPrint('✅ Route: AuthCubit signed out');
+                    } catch (e) {
+                      debugPrint(
+                        '⚠️ Route: Failed to sign out from AuthCubit: $e',
+                      );
+                    }
 
-                // Step 2: Clear cart token
-                try {
-                  await WooCartTokenStorage.clearCartToken();
-                  debugPrint('✅ Route: WooCartToken cleared');
-                } catch (e) {
-                  debugPrint('⚠️ Route: Failed to clear WooCartToken: $e');
-                }
+                    // Step 2: Clear WooCommerce JWT token
+                    try {
+                      await WooJwtTokenStorage.clearToken();
+                      debugPrint('✅ Route: WooJWT token cleared');
+                    } catch (e) {
+                      debugPrint('⚠️ Route: Failed to clear WooJWT token: $e');
+                    }
 
-                // Step 3: Clear all cookies (WP cookies: wordpress_logged_in_, woocommerce_items_in_cart, wp_woocommerce_session_)
-                try {
-                  await ApiDioClient.clearAllCookies();
-                  debugPrint(
-                    '✅ Route: All cookies cleared (including WP cookies)',
-                  );
-                } catch (e) {
-                  debugPrint('⚠️ Route: Failed to clear cookies: $e');
-                }
+                    // Step 3: Clear cart token
+                    try {
+                      await WooCartTokenStorage.clearCartToken();
+                      debugPrint('✅ Route: WooCartToken cleared');
+                    } catch (e) {
+                      debugPrint('⚠️ Route: Failed to clear WooCartToken: $e');
+                    }
 
-                // Step 4: Clear wishlist (user-specific data)
-                try {
-                  final wishlistViewModel = GetIt.I<WishlistViewModel>();
-                  wishlistViewModel.clearAll();
-                  debugPrint('✅ Route: Wishlist cleared');
-                } catch (e) {
-                  debugPrint('⚠️ Route: Failed to clear wishlist: $e');
-                }
+                    // Step 4: Clear all cookies (WP cookies: wordpress_logged_in_, woocommerce_items_in_cart, wp_woocommerce_session_)
+                    try {
+                      await ApiDioClient.clearAllCookies();
+                      debugPrint(
+                        '✅ Route: All cookies cleared (including WP cookies)',
+                      );
+                    } catch (e) {
+                      debugPrint('⚠️ Route: Failed to clear cookies: $e');
+                    }
 
-                debugPrint('✅ Route: Platform-specific cleanup completed');
+                    // Step 5: Clear wishlist (user-specific data)
+                    try {
+                      final wishlistViewModel = GetIt.I<WishlistViewModel>();
+                      wishlistViewModel.clearAll();
+                      debugPrint('✅ Route: Wishlist cleared');
+                    } catch (e) {
+                      debugPrint('⚠️ Route: Failed to clear wishlist: $e');
+                    }
+
+                    debugPrint('✅ Route: Platform-specific cleanup completed');
+                  },
+                );
 
                 // Step 5: Navigate to home after sign out
                 await Future.delayed(const Duration(milliseconds: 300));
@@ -703,9 +725,7 @@ final GoRouter appRouter = GoRouter(
                   debugPrint('⚠️ Route: Context not mounted, cannot navigate');
                 }
               },
-              bottomNavigationBar: _getNavbarForRoute(
-                state.uri.path,
-              ),
+              bottomNavigationBar: _getNavbarForRoute(state.uri.path),
             ),
           ),
           transitionsBuilder: (context, animation, secondaryAnimation, child) {
@@ -892,19 +912,19 @@ Widget? _getNavbarForRoute(String location) {
           bloc: GetIt.I<WishlistViewModel>(),
           buildWhen: (previous, current) {
             // Rebuild when wishlist count changes
-            final prevCount = previous is WishlistLoadedState 
-                ? previous.items.length 
+            final prevCount = previous is WishlistLoadedState
+                ? previous.items.length
                 : 0;
-            final currCount = current is WishlistLoadedState 
-                ? current.items.length 
+            final currCount = current is WishlistLoadedState
+                ? current.items.length
                 : 0;
             return prevCount != currCount;
           },
           builder: (context, wishlistState) {
-            final wishlistCount = wishlistState is WishlistLoadedState 
-                ? wishlistState.items.length 
+            final wishlistCount = wishlistState is WishlistLoadedState
+                ? wishlistState.items.length
                 : 0;
-            
+
             // Get AuthCubit from GetIt to listen to auth state changes
             try {
               final authCubit = GetIt.I<AuthCubit>();
@@ -1052,6 +1072,51 @@ List<NavbarItem> _buildNavbarItems(
       tooltip: isAuthenticated ? 'Profile' : 'Sign In',
     ),
   ];
+}
+
+/// Load user API data and set it to AccountCubit
+/// This fetches fresh user data from the API (username, email, etc.)
+Future<void> _loadUserApiData(AccountCubit accountCubit) async {
+  try {
+    debugPrint('🔍 AccountCubit Route: Loading user API data...');
+    final jwtToken = await WooJwtTokenStorage.loadToken();
+    if (jwtToken != null && jwtToken.accessToken.isNotEmpty) {
+      debugPrint('🔍 AccountCubit Route: JWT token found, calling API...');
+      final authService = GetIt.I<WooAuthService>();
+      final authHeader = 'Bearer ${jwtToken.accessToken}';
+      final userMeResponse = await authService.getUsersMe(authHeader);
+
+      debugPrint('✅ AccountCubit Route: getUsersMe API call successful');
+      debugPrint(
+        '👤 AccountCubit Route: User name from API (raw): "${userMeResponse.name}"',
+      );
+
+      // Prepare user data map with username, email, etc.
+      final userData = {
+        'id': userMeResponse.id,
+        'name': userMeResponse.name, // Use name directly, no processing
+        'url': userMeResponse.url,
+        'description': userMeResponse.description,
+        'link': userMeResponse.link,
+        'slug': userMeResponse.slug,
+        'avatar_urls': userMeResponse.avatarUrls?.toJson(),
+        'is_super_admin': userMeResponse.isSuperAdmin,
+        'woocommerce_meta': userMeResponse.woocommerceMeta?.toJson(),
+      };
+
+      debugPrint(
+        '👤 AccountCubit Route: Setting user data with name: "${userData['name']}"',
+      );
+      accountCubit.setUserApiData(userData);
+    } else {
+      debugPrint('⚠️ AccountCubit Route: No JWT token found');
+      accountCubit.setUserApiData(null);
+    }
+  } catch (e, stackTrace) {
+    debugPrint('⚠️ AccountCubit Route: Error calling getUsersMe API: $e');
+    debugPrint('⚠️ AccountCubit Route: Stack trace: $stackTrace');
+    accountCubit.setUserApiData(null);
+  }
 }
 
 /// Navigate to page based on index

--- a/projects/storefront_woo/pubspec.yaml
+++ b/projects/storefront_woo/pubspec.yaml
@@ -23,8 +23,8 @@ dependencies:
   # STATE MANAGEMENT & DEPENDENCY INJECTION
   # ────────────────────────────────
   flutter_bloc: ^9.1.1     # BLoC pattern for managing application state
-  get_it: ^7.7.0           # Simple service locator (manual DI)
-  injectable: ^2.5.1       # Annotation-based code generation for get_it
+  get_it: ^8.3.0           # Simple service locator (manual DI)
+  injectable: ^2.7.1       # Annotation-based code generation for get_it
 
   # ────────────────────────────────
   # ROUTING / NAVIGATION
@@ -59,7 +59,7 @@ dev_dependencies:
   # ────────────────────────────────
   # CODE GENERATION
   # ────────────────────────────────
-  injectable_generator: ^2.6.2     # Generates code for injectable (DI)
+  injectable_generator: ^2.7.0     # Generates code for injectable (DI) - compatible with freezed 2.x
   build_runner: ^2.5.4            # Core tool for running code generation
   slang_build_runner: ^4.7.0      # Code generator for slang localization
   flutter_gen_runner: any         # Generator for flutter_gen (assets, colors, fonts, etc.)


### PR DESCRIPTION
# 📋 PR Description

This PR refactors the AccountCubit architecture to remove callback dependencies and improve separation of concerns. The changes eliminate the `GetUsersMeCallback` dependency, move API data handling to platform-specific routes, and centralize signout logic within AccountCubit. Additionally, the `GetUsersMeResponse` model is updated to handle flexible `meta` field types.

### ✨ Features Added

#### 🔧 AccountCubit Refactoring
•⁠  ⁠*Removed GetUsersMeCallback Dependency*: Eliminated callback-based dependency injection pattern
•⁠  ⁠*Direct Data Injection*: Added `setUserApiData()` method for platform-specific implementations to provide user data directly
•⁠  ⁠*Centralized Signout Logic*: Added `signOut()` method that handles all account-related cleanup internally
•⁠  ⁠*Platform-Specific Callback Support*: Signout accepts optional callback for platform-specific cleanup (AuthCubit, tokens, cookies, etc.)

#### 🏗️ Architecture Improvements
•⁠  ⁠*Separation of Concerns*: AccountCubit no longer depends on platform-specific API implementations
•⁠  ⁠*Route-Level API Handling*: API calls moved to route level (`app_routes.dart`) where platform-specific logic belongs
•⁠  ⁠*State Management*: AccountCubit manages its own state clearing without external dependencies
•⁠  ⁠*Injectable Pattern*: AccountCubit remains `@injectable` but without callback dependencies

#### 🐛 Bug Fixes
•⁠  ⁠*GetUsersMeResponse Meta Field*: Changed `meta` field from `List<dynamic>?` to `dynamic` to handle both List and Map types from API
•⁠  ⁠*Signout State Clearing*: Fixed issue where user data persisted after signout by properly clearing AccountCubit state
•⁠  ⁠*Build Runner Warnings*: Resolved "Missing dependencies" warning for `GetUsersMeCallback` in generated DI config

### 🏗️ Architecture & State Management

#### AccountCubit Refactoring
•⁠  ⁠*Removed Callback Pattern*: 
  - Eliminated `GetUsersMeCallback` typedef
  - Removed `getUsersMeCallback` constructor parameter
  - Removed `_getUsersMeCallback` private field
  
•⁠  ⁠*New Data Injection Pattern*:
  - Added `setUserApiData(Map<String, dynamic>? userData)` method
  - Platform-specific routes call API and pass data directly
  - AccountCubit stores data in `_userApiData` field
  
•⁠  ⁠*Signout Implementation*:
  - Added `signOut({Future<void> Function()? onSignOut})` method
  - Clears user API data (`_userApiData = null`)
  - Calls `clearAccountData()` to reset state
  - Accepts optional callback for platform-specific cleanup

#### Route-Level API Handling
•⁠  ⁠*`_loadUserApiData()` Function*: 
  - Fetches user data from WooCommerce API
  - Handles JWT token retrieval
  - Calls `accountCubit.setUserApiData()` with response
  - Called when profile route is accessed
  
•⁠  ⁠*Signout Flow*:
  - Route calls `accountCubit.signOut()` with platform-specific callback
  - Callback handles: AuthCubit signout, JWT token clearing, cart token clearing, cookies clearing, wishlist clearing



#### Files Modified

**Core Package:**
- `packages/core/lib/src/views/account/cubit/account_cubit.dart`
  - Removed `GetUsersMeCallback` typedef
  - Removed callback-based constructor parameter
  - Added `setUserApiData()` method
  - Added `signOut()` method
  - Updated `_loadProfileData()` to accept `userApiData` parameter

**APIs Package:**
- `packages/apis/lib/network/remote/woocommerce/auth/freezed_model/response/get_users_me_response.dart`
  - Changed `meta` field type from `List<dynamic>?` to `dynamic`
  - Regenerated freezed/json_serializable code

**Storefront Woo Project:**
- `projects/storefront_woo/lib/app/routes/app_routes.dart`
  - Added `_loadUserApiData()` function for API calls
  - Updated profile route to call `_loadUserApiData()` before displaying AccountView
  - Updated signout handler to use `accountCubit.signOut()` with platform-specific callback
  - Removed AccountCubit override logic

**Generated Files:**
- `packages/core/lib/src/di/config/config_di.config.dart`
  - AccountCubit registration now parameterless: `_i111.AccountCubit()`
  - No more `GetUsersMeCallback` dependency warning

### 🔒 Code Changes Details

#### AccountCubit Changes
```dart
// Before: Callback-based dependency injection
@injectable
class AccountCubit extends BaseViewModelCubit<AccountState> {
  AccountCubit({
    GetUsersMeCallback? getUsersMeCallback,
  }) : super(const AccountState()) {
    _getUsersMeCallback = getUsersMeCallback;
  }
  GetUsersMeCallback? _getUsersMeCallback;
}

// After: Direct data injection
@injectable
class AccountCubit extends BaseViewModelCubit<AccountState> {
  AccountCubit() : super(const AccountState());
  
  Map<String, dynamic>? _userApiData;
  
  void setUserApiData(Map<String, dynamic>? userData) {
    _userApiData = userData;
  }
  
  Future<void> signOut({Future<void> Function()? onSignOut}) async {
    _userApiData = null;
    clearAccountData();
    if (onSignOut != null) {
      await onSignOut();
    }
  }
}
```

#### Route-Level API Handling
```dart
// Route calls API and passes data to AccountCubit
Future<void> _loadUserApiData(AccountCubit accountCubit) async {
  final jwtToken = await WooJwtTokenStorage.loadToken();
  if (jwtToken != null && jwtToken.accessToken.isNotEmpty) {
    final authService = GetIt.I<WooAuthService>();
    final authHeader = 'Bearer ${jwtToken.accessToken}';
    final userMeResponse = await authService.getUsersMe(authHeader);
    
    final userData = {
      'id': userMeResponse.id,
      'name': userMeResponse.name,
      'slug': userMeResponse.slug,
      // ... other fields
    };
    
    accountCubit.setUserApiData(userData);
  }
}
```

#### Signout Flow
```dart
// Route provides platform-specific cleanup via callback
await accountCubit.signOut(onSignOut: () async {
  await authCubit.signOut();
  await WooJwtTokenStorage.clearToken();
  await WooCartTokenStorage.clearCartToken();
  await ApiDioClient.clearAllCookies();
  wishlistViewModel.clearAll();
});
```

### 🎭 Benefits & Improvements

#### Architectural Benefits
•⁠  ⁠*Better Separation of Concerns*: Platform-specific API logic stays in routes, not in core package
•⁠  ⁠*Reduced Dependencies*: AccountCubit no longer depends on callback typedefs or platform-specific implementations
•⁠  ⁠*Cleaner DI Configuration*: No more "Missing dependencies" warnings in build_runner
•⁠  ⁠*More Testable*: AccountCubit can be tested without mocking callbacks

#### Code Quality Improvements
•⁠  ⁠*Simplified Constructor*: AccountCubit constructor is now parameterless and `@injectable` compatible
•⁠  ⁠*Explicit Data Flow*: Clear data flow from route → AccountCubit via `setUserApiData()`
•⁠  ⁠*Centralized Signout*: All account-related cleanup happens in one place
•⁠  ⁠*Flexible API Response*: `meta` field now handles both List and Map types from different API versions

#### Bug Fixes
•⁠  ⁠*Signout State Clearing*: User data no longer persists after signout
•⁠  ⁠*Type Cast Errors*: Fixed `_Map<String, dynamic>' is not a subtype of type 'List<dynamic>?'` error
•⁠  ⁠*Build Warnings*: Eliminated injectable_generator warnings about missing `GetUsersMeCallback`

### 📱 Migration Guide

#### For Platform-Specific Implementations

**Before:**
```dart
// Had to register GetUsersMeCallback before core initialization
getIt.registerFactory<GetUsersMeCallback>(
  () => () async {
    // API call logic
    return userData;
  },
);
```

**After:**
```dart
// Call API in route and pass data directly
final userMeResponse = await authService.getUsersMe(authHeader);
accountCubit.setUserApiData({
  'id': userMeResponse.id,
  'name': userMeResponse.name,
  // ... other fields
});
```

#### Signout Implementation

**Before:**
```dart
// Had to manually clear AccountCubit state
accountCubit.setUserApiData(null);
accountCubit.clearAccountData();
await authCubit.signOut();
// ... other cleanup
```

**After:**
```dart
// AccountCubit handles its own cleanup
await accountCubit.signOut(onSignOut: () async {
  // Only platform-specific cleanup
  await authCubit.signOut();
  // ... other platform-specific cleanup
});
```

### 💡 Development Best Practices

#### Architecture Principles
•⁠  ⁠*Core Package Independence*: Core package should not depend on platform-specific implementations
•⁠  ⁠*Data Injection Pattern*: Platform-specific data should be injected via explicit methods, not callbacks
•⁠  ⁠*Separation of Concerns*: API calls belong in routes, state management belongs in cubits
•⁠  ⁠*Injectable Compatibility*: All `@injectable` classes should have parameterless constructors or use proper DI annotations

#### Error Handling
```dart
// Route-level error handling for API calls
try {
  final userMeResponse = await authService.getUsersMe(authHeader);
  accountCubit.setUserApiData(userData);
} catch (e, stackTrace) {
  debugPrint('⚠️ Error calling getUsersMe API: $e');
  accountCubit.setUserApiData(null); // Clear on error
}
```

#### State Management
•⁠  ⁠*Centralized Cleanup*: AccountCubit manages its own state clearing
•⁠  ⁠*Optional Callbacks*: Platform-specific cleanup provided via optional callback
•⁠  ⁠*Immutable State*: AccountState uses `copyWith` pattern for updates

### 📝 Code Examples

#### Setting User API Data in Route
```dart
GoRoute(
  path: '/profile',
  pageBuilder: (BuildContext context, GoRouterState state) {
    final accountCubit = GetIt.I<AccountCubit>();
    
    // Load user API data before displaying view
    _loadUserApiData(accountCubit);
    
    return AccountView(/* ... */);
  },
)
```

#### Signout Implementation
```dart
onSignOut: () async {
  await accountCubit.signOut(onSignOut: () async {
    // Platform-specific cleanup
    await authCubit.signOut();
    await WooJwtTokenStorage.clearToken();
    // ... other cleanup
  });
  
  // Navigate after signout
  context.go('/home');
}
```

### 🔧 Build & Generation

#### Required Steps
1. **Run build_runner for core package:**
   ```bash
   cd packages/core
   flutter pub run build_runner build --delete-conflicting-outputs
   ```

2. **Run build_runner for apis package:**
   ```bash
   cd packages/apis
   flutter pub run build_runner build --delete-conflicting-outputs
   ```

3. **Verify generated files:**
   - `packages/core/lib/src/di/config/config_di.config.dart` should have parameterless `AccountCubit()` registration
   - `packages/apis/lib/network/remote/woocommerce/auth/freezed_model/response/get_users_me_response.g.dart` should have `meta: json['meta']` (no cast)

### 🐛 Bug Fixes & Improvements

#### Fixed Issues
- **Signout State Persistence**: Fixed issue where user data (username, email) persisted after signout
- **Type Cast Error**: Fixed `_Map<String, dynamic>' is not a subtype of type 'List<dynamic>?'` error in `GetUsersMeResponse`
- **Build Runner Warnings**: Eliminated "Missing dependencies" warning for `GetUsersMeCallback` in injectable_generator
- **DI Configuration**: AccountCubit now properly registered without callback dependencies

#### Performance Improvements
- **Simplified DI**: Removed unnecessary callback registration from config_di.dart
- **Cleaner Architecture**: Reduced coupling between core and platform-specific code
- **Better Error Handling**: API errors in route don't crash AccountCubit initialization

---

## ✅ Checklist

- [x] Code follows the project standards and guidelines.
- [x] Relevant unit tests are written and all tests are passing.
- [ ] Test coverage is adequate for the changes.
- [x] Any unnecessary files or debug statements have been removed.
- [ ] Documentation is updated where necessary.
- [x] The PR has been reviewed by at least one team member before merging.

---


## 🛠 Steps to Test

1. **Run build_runner for code generation:**
   ```bash
   cd packages/core && flutter pub run build_runner build --delete-conflicting-outputs
   cd packages/apis && flutter pub run build_runner build --delete-conflicting-outputs
   ```

2. **Run the storefront_woo app:**
   ```bash
   cd projects/storefront_woo
   flutter pub get
   flutter run
   ```

3. **Test Account View:**
   - Navigate to `/profile` route
   - Verify user data (username, email) is loaded from API
   - Check that AccountCubit state is properly initialized

4. **Test Signout:**
   - Click "Sign In" button (if authenticated) or navigate to account view
   - Click signout option
   - Verify that:
     - User data (username, email) is cleared from AccountCubit
     - AccountCubit state is reset to initial state
     - Navigation redirects to home page
     - No user data persists in AccountView

5. **Test API Error Handling:**
   - Simulate API error (e.g., invalid token)
   - Verify that `accountCubit.setUserApiData(null)` is called
   - Verify that AccountCubit falls back to default/mock data

6. **Verify Build Warnings:**
   - Run `flutter pub run build_runner build` in core package
   - Verify no "Missing dependencies" warnings for `GetUsersMeCallback`

