### PR TITLE
Projects -> Storefront Supabase - Enhance authentication UI in storefront_supabase

### DIFF
--- a/projects/storefront_supabase/assets/app_config.json
+++ b/projects/storefront_supabase/assets/app_config.json
@@ -272,6 +272,8 @@
       },
       "sign_in": {
         "app_name": "MasterFabric S Store",
+        "app_bar_title": "Sign In",
+        "welcome_title": "Welcome to Masterfabric S Store",
         "tab_sign_in": "Sign In",
         "tab_sign_up": "Sign Up",
         "email_label": "Email",
@@ -288,6 +290,8 @@
       },
       "sign_up": {
         "app_name": "MasterFabric S Store",
+        "app_bar_title": "Sign Up",
+        "welcome_title": "Welcome to Masterfabric S Store",
         "tab_sign_in": "Sign In",
         "tab_sign_up": "Sign Up",
         "email_label": "Email",

--- a/projects/storefront_supabase/lib/app/routes/app_routes.dart
+++ b/projects/storefront_supabase/lib/app/routes/app_routes.dart
@@ -582,9 +582,8 @@ class _AdminScreenState extends State<AdminScreen> {
 // Colors from navbar_configuration (black/white only, no blue). OsmeaComponents.navbar().
 
 bool _shouldShowNavbarForPath(String path) {
-  // Routes that should NOT show navbar (only special pages like auth, onboarding, splash, etc.)
+  // Routes that should NOT show navbar (only special pages like onboarding, splash, etc.)
   final hideNavbarRoutes = [
-    '/auth', // Authentication pages
     '/onboarding', // Onboarding flow
     '/', // Root/splash route
     '/empty', // Empty state pages

--- a/projects/storefront_supabase/lib/app/views/view_profile/change_password/change_password_view.dart
+++ b/projects/storefront_supabase/lib/app/views/view_profile/change_password/change_password_view.dart
@@ -42,15 +42,14 @@ class ChangePasswordView extends MasterViewCubit<ChangePasswordViewModel, Change
   @override
   Widget viewContent(
       BuildContext context, ChangePasswordViewModel viewModel, ChangePasswordState state) {
-    final resources = context.resources;
     if (state is ChangePasswordLoading) {
       return Center(
-      child: OsmeaComponents.loading(
-        type: LoadingType.circularFade,
-        size: 36,
-        color: OsmeaColors.black,
-      ),
-    );
+        child: OsmeaComponents.loading(
+          type: LoadingType.circularFade,
+          size: 36,
+          color: OsmeaColors.black,
+        ),
+      );
     }
 
     if (state is ChangePasswordError) {
@@ -59,74 +58,96 @@ class ChangePasswordView extends MasterViewCubit<ChangePasswordViewModel, Change
 
     return SingleChildScrollView(
       padding: EdgeInsets.symmetric(horizontal: context.spacing16, vertical: context.spacing24),
+      child: _ChangePasswordForm(viewModel: viewModel),
+    );
+  }
+}
+
+class _ChangePasswordForm extends StatefulWidget {
+  final ChangePasswordViewModel viewModel;
+
+  const _ChangePasswordForm({
+    required this.viewModel,
+  });
+
+  @override
+  State<_ChangePasswordForm> createState() => _ChangePasswordFormState();
+}
+
+class _ChangePasswordFormState extends State<_ChangePasswordForm> {
+  bool _obscureNewPassword = true;
+  bool _obscureConfirmPassword = true;
+
+  @override
+  Widget build(BuildContext context) {
+    final resources = context.resources;
+    final viewModel = widget.viewModel;
+    return Container(
+      padding: EdgeInsets.all(context.spacing12),
+      decoration: BoxDecoration(
+        color: OsmeaColors.white,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: OsmeaColors.silver, width: 1),
+      ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          Container(
-            padding: EdgeInsets.all(context.spacing12),
-            decoration: BoxDecoration(
-              color: OsmeaColors.white,
-              borderRadius: BorderRadius.circular(8),
-              border: Border.all(color: OsmeaColors.silver, width: 1),
+          OsmeaComponents.textField(
+            controller: viewModel.newPasswordController,
+            label: resources.newPassword,
+            variant: TextFieldVariant.outlined,
+            focusColor: OsmeaColors.black,
+            obscureText: _obscureNewPassword,
+            type: TextFieldType.text,
+            suffixIcon: IconButton(
+              icon: Icon(
+                _obscureNewPassword ? Icons.visibility_off_outlined : Icons.visibility_outlined,
+                color: OsmeaColors.black,
+                size: context.iconSizeSmall,
+              ),
+              onPressed: () => setState(() => _obscureNewPassword = !_obscureNewPassword),
             ),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: [
-                _buildEditableField(
-                  context,
-                  viewModel.newPasswordController,
-                  resources.newPassword,
-                  obscureText: true,
-                ),
-                SizedBox(height: context.spacing16),
-                _buildEditableField(
-                  context,
-                  viewModel.confirmNewPasswordController,
-                  resources.confirmNewPassword,
-                  obscureText: true,
-                ),
-                SizedBox(height: context.spacing24),
-                OsmeaComponents.button(
-                  text: resources.updatePassword,
-                  variant: ButtonVariant.primary,
-                  backgroundColor: OsmeaColors.black,
-                  textColor: OsmeaColors.white,
-                  fullWidth: true,
-                  onPressed: () async {
-                    final success = await viewModel.changePassword();
-                    if (!context.mounted) return;
-                    if (success) {
-                      context.showSnackbar(
-                        message: resources.passwordChanged,
-                        type: SnackbarType.success,
-                      );
-                      context.pop();
-                    } else {
-                      context.snackbarWarning(resources.failedChangePassword);
-                    }
-                  },
-                ),
-              ],
+          ),
+          SizedBox(height: context.spacing16),
+          OsmeaComponents.textField(
+            controller: viewModel.confirmNewPasswordController,
+            label: resources.confirmNewPassword,
+            variant: TextFieldVariant.outlined,
+            focusColor: OsmeaColors.black,
+            obscureText: _obscureConfirmPassword,
+            type: TextFieldType.text,
+            suffixIcon: IconButton(
+              icon: Icon(
+                _obscureConfirmPassword ? Icons.visibility_off_outlined : Icons.visibility_outlined,
+                color: OsmeaColors.black,
+                size: context.iconSizeSmall,
+              ),
+              onPressed: () => setState(() => _obscureConfirmPassword = !_obscureConfirmPassword),
             ),
+          ),
+          SizedBox(height: context.spacing24),
+          OsmeaComponents.button(
+            text: resources.updatePassword,
+            variant: ButtonVariant.primary,
+            backgroundColor: OsmeaColors.black,
+            textColor: OsmeaColors.white,
+            fullWidth: true,
+            onPressed: () async {
+              final success = await viewModel.changePassword();
+              if (!context.mounted) return;
+              if (success) {
+                context.showSnackbar(
+                  message: resources.passwordChanged,
+                  type: SnackbarType.success,
+                );
+                context.pop();
+              } else {
+                context.snackbarWarning(resources.failedChangePassword);
+              }
+            },
           ),
         ],
       ),
-    );
-  }
-
-  Widget _buildEditableField(
-    BuildContext context,
-    TextEditingController controller,
-    String label, {
-    bool obscureText = false,
-  }) {
-    return OsmeaComponents.textField(
-      controller: controller,
-      label: label,
-      variant: TextFieldVariant.outlined,
-      focusColor: OsmeaColors.black,
-      obscureText: obscureText,
-      type: TextFieldType.text,
     );
   }
 }

--- a/projects/storefront_supabase/lib/app/views/view_profile/profile_view.dart
+++ b/projects/storefront_supabase/lib/app/views/view_profile/profile_view.dart
@@ -116,7 +116,30 @@ class ProfileView extends MasterViewCubit<ProfileViewModel, ProfileState> {
                 ],
               );
             }
-            return AppBar(toolbarHeight: 0);
+            // Unauthenticated: app bar title from config
+            final theme = Theme.of(context);
+            final configHelper = AssetConfigHelper();
+            final showLogin = state is ProfileUnauthenticated && state.showLoginView;
+            final title = showLogin
+                ? configHelper.getString('auth_configuration.sign_in.app_bar_title', 'Sign In')
+                : configHelper.getString('auth_configuration.sign_up.app_bar_title', 'Sign Up');
+            return OsmeaComponents.appBar(
+              title: OsmeaComponents.text(
+                title,
+                textStyle: theme.textTheme.titleLarge?.copyWith(
+                  fontWeight: FontWeight.w600,
+                  color: OsmeaColors.black,
+                ),
+              ),
+              backgroundColor: OsmeaColors.white,
+              foregroundColor: OsmeaColors.black,
+              elevation: 0,
+              leading: OsmeaComponents.iconButton(
+                onPressed: () => context.go('/home'),
+                icon: Icon(Icons.arrow_back, color: OsmeaColors.black),
+                backgroundColor: OsmeaColors.transparent,
+              ),
+            );
           },
         );
 
@@ -168,7 +191,7 @@ class ProfileView extends MasterViewCubit<ProfileViewModel, ProfileState> {
                 child: OsmeaComponents.column(
                   mainAxisAlignment: MainAxisAlignment.center,
                   children: [
-                    const LogoHeaderWidget(),
+                    LogoHeaderWidget(isSignUp: !state.showLoginView),
                     if (state.errorMessage != null) ...[
                       OsmeaComponents.text(
                         state.errorMessage!,

--- a/projects/storefront_supabase/lib/app/views/view_profile/widgets/login_form_widget.dart
+++ b/projects/storefront_supabase/lib/app/views/view_profile/widgets/login_form_widget.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:storefront_supabase/app/views/view_profile/models/profile_view_model.dart';
 import 'package:storefront_supabase/src/resources/resources.g.dart';
 
-class LoginFormWidget extends StatelessWidget {
+class LoginFormWidget extends StatefulWidget {
   final ProfileViewModel viewModel;
   final VoidCallback onSwitchToSignup;
 
@@ -14,12 +14,19 @@ class LoginFormWidget extends StatelessWidget {
   });
 
   @override
+  State<LoginFormWidget> createState() => _LoginFormWidgetState();
+}
+
+class _LoginFormWidgetState extends State<LoginFormWidget> {
+  bool _obscurePassword = true;
+
+  @override
   Widget build(BuildContext context) {
     final resources = context.resources;
     return OsmeaComponents.column(
       children: [
         OsmeaComponents.textField(
-          controller: viewModel.emailController,
+          controller: widget.viewModel.emailController,
           label: resources.email,
           prefixIcon: const Icon(
             Icons.email_outlined,
@@ -31,7 +38,7 @@ class LoginFormWidget extends StatelessWidget {
         ),
         OsmeaComponents.sizedBox(height: 16),
         OsmeaComponents.textField(
-          controller: viewModel.passwordController,
+          controller: widget.viewModel.passwordController,
           label: resources.password,
           prefixIcon: const Icon(
             Icons.lock_outline,
@@ -40,30 +47,37 @@ class LoginFormWidget extends StatelessWidget {
           variant: TextFieldVariant.outlined,
           focusColor: OsmeaColors.black,
           type: TextFieldType.password,
-          obscureText: true,
+          obscureText: _obscurePassword,
+          suffixIcon: IconButton(
+            icon: Icon(
+              _obscurePassword ? Icons.visibility_off_outlined : Icons.visibility_outlined,
+              color: OsmeaColors.black,
+              size: context.iconSizeSmall,
+            ),
+            onPressed: () => setState(() => _obscurePassword = !_obscurePassword),
+          ),
         ),
         OsmeaComponents.sizedBox(height: 24),
         OsmeaComponents.button(
           text: resources.signIn,
-          onPressed: viewModel.login,
+          onPressed: widget.viewModel.login,
           variant: ButtonVariant.primary,
           fullWidth: true,
           backgroundColor: OsmeaColors.black,
           textColor: OsmeaColors.white,
         ),
-                OsmeaComponents.sizedBox(height: 16),
-                GestureDetector(
-                  onTap: onSwitchToSignup,
-                  child: OsmeaComponents.text(
-                    resources.dontHaveAccount,
-                    textStyle: TextStyle(
-                      color: Theme.of(context).primaryColor,
-                      decoration: TextDecoration.underline,
-                    ),
-                  ),
-                ),
-              ],
-            );
-          }
-        }
-        
+        OsmeaComponents.sizedBox(height: 16),
+        GestureDetector(
+          onTap: widget.onSwitchToSignup,
+          child: OsmeaComponents.text(
+            resources.dontHaveAccount,
+            textStyle: TextStyle(
+              color: Theme.of(context).primaryColor,
+              decoration: TextDecoration.underline,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/projects/storefront_supabase/lib/app/views/view_profile/widgets/logo_header_widget.dart
+++ b/projects/storefront_supabase/lib/app/views/view_profile/widgets/logo_header_widget.dart
@@ -3,10 +3,16 @@ import 'package:flutter/material.dart';
 import 'package:storefront_supabase/src/resources/resources.g.dart';
 
 class LogoHeaderWidget extends StatelessWidget {
-  const LogoHeaderWidget({super.key});
+  final bool isSignUp;
+
+  const LogoHeaderWidget({super.key, this.isSignUp = false});
 
   @override
   Widget build(BuildContext context) {
+    final configHelper = AssetConfigHelper();
+    final welcomeTitle = isSignUp
+        ? configHelper.getString('auth_configuration.sign_up.welcome_title', 'Welcome to Masterfabric S Store')
+        : configHelper.getString('auth_configuration.sign_in.welcome_title', 'Welcome to Masterfabric S Store');
     return OsmeaComponents.column(
       children: [
         OsmeaComponents.sizedBox(height: 60),
@@ -30,7 +36,7 @@ class LogoHeaderWidget extends StatelessWidget {
         ),
         OsmeaComponents.sizedBox(height: 24),
         OsmeaComponents.text(
-          context.resources.welcomeTitle,
+          welcomeTitle,
           textStyle: OsmeaTextStyle.headlineMedium(context).copyWith(
             fontWeight: FontWeight.w700,
             color: OsmeaColors.black,

--- a/projects/storefront_supabase/lib/app/views/view_profile/widgets/signup_form_widget.dart
+++ b/projects/storefront_supabase/lib/app/views/view_profile/widgets/signup_form_widget.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:storefront_supabase/app/views/view_profile/models/profile_view_model.dart';
 import 'package:storefront_supabase/src/resources/resources.g.dart';
 
-class SignupFormWidget extends StatelessWidget {
+class SignupFormWidget extends StatefulWidget {
   final ProfileViewModel viewModel;
   final VoidCallback onSwitchToLogin;
 
@@ -14,12 +14,20 @@ class SignupFormWidget extends StatelessWidget {
   });
 
   @override
+  State<SignupFormWidget> createState() => _SignupFormWidgetState();
+}
+
+class _SignupFormWidgetState extends State<SignupFormWidget> {
+  bool _obscurePassword = true;
+  bool _obscureConfirmPassword = true;
+
+  @override
   Widget build(BuildContext context) {
     final resources = context.resources;
     return OsmeaComponents.column(
       children: [
         OsmeaComponents.textField(
-          controller: viewModel.usernameController,
+          controller: widget.viewModel.usernameController,
           label: resources.username,
           prefixIcon: const Icon(
             Icons.person_outline,
@@ -30,7 +38,7 @@ class SignupFormWidget extends StatelessWidget {
         ),
         OsmeaComponents.sizedBox(height: 16),
         OsmeaComponents.textField(
-          controller: viewModel.emailController,
+          controller: widget.viewModel.emailController,
           label: resources.email,
           prefixIcon: const Icon(
             Icons.email_outlined,
@@ -42,7 +50,7 @@ class SignupFormWidget extends StatelessWidget {
         ),
         OsmeaComponents.sizedBox(height: 16),
         OsmeaComponents.textField(
-          controller: viewModel.passwordController,
+          controller: widget.viewModel.passwordController,
           label: resources.password,
           prefixIcon: const Icon(
             Icons.lock_outline,
@@ -51,11 +59,19 @@ class SignupFormWidget extends StatelessWidget {
           variant: TextFieldVariant.outlined,
           focusColor: OsmeaColors.black,
           type: TextFieldType.password,
-          obscureText: true,
+          obscureText: _obscurePassword,
+          suffixIcon: IconButton(
+            icon: Icon(
+              _obscurePassword ? Icons.visibility_off_outlined : Icons.visibility_outlined,
+              color: OsmeaColors.black,
+              size: context.iconSizeSmall,
+            ),
+            onPressed: () => setState(() => _obscurePassword = !_obscurePassword),
+          ),
         ),
         OsmeaComponents.sizedBox(height: 16),
         OsmeaComponents.textField(
-          controller: viewModel.confirmPasswordController,
+          controller: widget.viewModel.confirmPasswordController,
           label: resources.confirmNewPassword,
           prefixIcon: const Icon(
             Icons.lock_outline,
@@ -64,30 +80,37 @@ class SignupFormWidget extends StatelessWidget {
           variant: TextFieldVariant.outlined,
           focusColor: OsmeaColors.black,
           type: TextFieldType.password,
-          obscureText: true,
+          obscureText: _obscureConfirmPassword,
+          suffixIcon: IconButton(
+            icon: Icon(
+              _obscureConfirmPassword ? Icons.visibility_off_outlined : Icons.visibility_outlined,
+              color: OsmeaColors.black,
+              size: context.iconSizeSmall,
+            ),
+            onPressed: () => setState(() => _obscureConfirmPassword = !_obscureConfirmPassword),
+          ),
         ),
         OsmeaComponents.sizedBox(height: 24),
         OsmeaComponents.button(
           text: resources.signup,
-          onPressed: viewModel.signup,
+          onPressed: widget.viewModel.signup,
           variant: ButtonVariant.primary,
           fullWidth: true,
           backgroundColor: OsmeaColors.black,
           textColor: OsmeaColors.white,
         ),
-                OsmeaComponents.sizedBox(height: 16),
-                GestureDetector(
-                  onTap: onSwitchToLogin,
-                  child: OsmeaComponents.text(
-                    resources.alreadyHaveAccount,
-                    textStyle: TextStyle(
-                      color: Theme.of(context).primaryColor,
-                      decoration: TextDecoration.underline,
-                    ),
-                  ),
-                ),
-              ],
-            );
-          }
-        }
-        
+        OsmeaComponents.sizedBox(height: 16),
+        GestureDetector(
+          onTap: widget.onSwitchToLogin,
+          child: OsmeaComponents.text(
+            resources.alreadyHaveAccount,
+            textStyle: TextStyle(
+              color: Theme.of(context).primaryColor,
+              decoration: TextDecoration.underline,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
## 📋 PR Description

Enhance authentication UI in storefront_supabase by:

- **App bar**: Add configurable titles for Sign In and Sign Up screens (from `auth_configuration` in app_config.json)
- **Welcome message**: Display "Welcome to Masterfabric S Store" from config on both login and signup
- **Bottom bar**: Show bottom navigation bar on auth screen (remove `/auth` from hideNavbarRoutes)
- **Back button**: Add app bar with back button on unauthenticated profile (login/signup) view
- **Password visibility**: Add show/hide toggle to password fields in login, signup, and change password forms
- **Refactor**: Convert LoginFormWidget and SignupFormWidget to StatefulWidget; extract ChangePasswordForm as StatefulWidget

---
## ✅ Checklist

- [x] Code follows the project standards and guidelines.
- [x] Relevant unit tests are written and all tests are passing.
- [x] Test coverage is adequate for the changes.
- [x] Any unnecessary files or debug statements have been removed.
- [x] Documentation is updated where necessary.
- [x] The PR has been reviewed by at least one team member before merging.

---
## 🛠 Steps to Test

1. Run the storefront_supabase app and navigate to Profile (or /auth when unauthenticated)
2. **Login screen**: Verify app bar shows "Sign In", welcome text "Welcome to Masterfabric S Store", bottom bar is visible, back button navigates to home
3. **Password toggle**: On login form, tap the visibility icon on the password field to show/hide password
4. Switch to Sign Up and verify app bar shows "Sign Up", same welcome text, and password fields have visibility toggles
5. After login, go to Profile → Change Password and verify both password fields have visibility toggles
6. Change app_config.json `auth_configuration.sign_in.app_bar_title`, `auth_configuration.sign_up.app_bar_title`, and `auth_configuration.sign_in.welcome_title` / `sign_up.welcome_title` to confirm config-driven labels


