### PR TITLE
Projects -> Storefront Supabase - Improve Profile View Validation And Error Handling

### DIFF
--- a/projects/storefront_supabase/lib/app/views/view_profile/models/profile_view_model.dart
+++ b/projects/storefront_supabase/lib/app/views/view_profile/models/profile_view_model.dart
@@ -568,24 +568,31 @@ class ProfileViewModel extends BaseViewModelCubit<ProfileState> {
   }
 
   Future<void> signup() async {
+    final email = emailController.text.trim();
     if (emailController.text.isEmpty ||
         passwordController.text.isEmpty ||
         confirmPasswordController.text.isEmpty ||
         usernameController.text.isEmpty) {
-      stateChanger(
-          const ProfileUnauthenticated(errorMessage: 'Please fill all fields.'));
+      stateChanger(const ProfileUnauthenticated(
+          showLoginView: false, errorMessage: 'Please fill all fields.'));
+      return;
+    }
+    if (!email.contains('@')) {
+      stateChanger(const ProfileUnauthenticated(
+          showLoginView: false,
+          errorMessage: 'Please enter a valid email address.'));
       return;
     }
     if (passwordController.text != confirmPasswordController.text) {
-      stateChanger(
-          const ProfileUnauthenticated(errorMessage: 'Passwords do not match.'));
+      stateChanger(const ProfileUnauthenticated(
+          showLoginView: false, errorMessage: 'Passwords do not match.'));
       return;
     }
     stateChanger(ProfileLoading());
 
     try {
       final response = await _supabaseClient.auth.signUp(
-        email: emailController.text.trim(),
+        email: email,
         password: passwordController.text.trim(),
         data: {'username': usernameController.text.trim()},
       );
@@ -597,12 +604,15 @@ class ProfileViewModel extends BaseViewModelCubit<ProfileState> {
                 'Success! Please check your email to confirm your registration.'));
       } else {
         stateChanger(const ProfileUnauthenticated(
+            showLoginView: false,
             errorMessage: 'Signup failed. Please try again.'));
       }
     } on AuthException catch (e) {
-      stateChanger(ProfileUnauthenticated(errorMessage: e.message));
+      stateChanger(ProfileUnauthenticated(
+          showLoginView: false, errorMessage: e.message));
     } catch (e) {
       stateChanger(const ProfileUnauthenticated(
+          showLoginView: false,
           errorMessage: 'An unexpected error occurred.'));
     }
   }

--- a/projects/storefront_supabase/lib/app/views/view_profile/models/profile_view_model.dart
+++ b/projects/storefront_supabase/lib/app/views/view_profile/models/profile_view_model.dart
@@ -534,16 +534,23 @@ class ProfileViewModel extends BaseViewModelCubit<ProfileState> {
   }
 
   Future<void> login() async {
-    if (emailController.text.isEmpty || passwordController.text.isEmpty) {
+    final email = emailController.text.trim();
+    final password = passwordController.text.trim();
+    if (email.isEmpty || password.isEmpty) {
       stateChanger(const ProfileUnauthenticated(
           errorMessage: 'Please enter email and password.'));
+      return;
+    }
+    if (!email.contains('@')) {
+      stateChanger(const ProfileUnauthenticated(
+          errorMessage: 'Please enter a valid email address.'));
       return;
     }
     stateChanger(ProfileLoading());
     try {
       final response = await _supabaseClient.auth.signInWithPassword(
-        email: emailController.text.trim(),
-        password: passwordController.text.trim(),
+        email: email,
+        password: password,
       );
       if (response.user == null) {
         stateChanger(const ProfileUnauthenticated(

--- a/projects/storefront_supabase/lib/app/views/view_profile/profile_view.dart
+++ b/projects/storefront_supabase/lib/app/views/view_profile/profile_view.dart
@@ -165,9 +165,7 @@ class ProfileView extends MasterViewCubit<ProfileViewModel, ProfileState> {
             }
           });
         }
-        if (state is ProfileUnauthenticated &&
-            state.errorMessage != null &&
-            state.showLoginView) {
+        if (state is ProfileUnauthenticated && state.errorMessage != null) {
           context.snackbarWarning(state.errorMessage!);
         }
       },
@@ -196,16 +194,6 @@ class ProfileView extends MasterViewCubit<ProfileViewModel, ProfileState> {
                   mainAxisAlignment: MainAxisAlignment.center,
                   children: [
                     LogoHeaderWidget(isSignUp: !state.showLoginView),
-                    if (state.errorMessage != null && !state.showLoginView) ...[
-                      OsmeaComponents.text(
-                        state.errorMessage!,
-                        color: state.errorMessage!.startsWith('Success')
-                            ? OsmeaColors.black
-                            : OsmeaColors.black,
-                        textAlign: TextAlign.center,
-                      ),
-                      OsmeaComponents.sizedBox(height: 16),
-                    ],
                     AnimatedSwitcher(
                       duration: const Duration(milliseconds: 300),
                       child: state.showLoginView

--- a/projects/storefront_supabase/lib/app/views/view_profile/profile_view.dart
+++ b/projects/storefront_supabase/lib/app/views/view_profile/profile_view.dart
@@ -158,13 +158,17 @@ class ProfileView extends MasterViewCubit<ProfileViewModel, ProfileState> {
       bloc: viewModel,
       listener: (context, state) {
         if (state is ProfileAuthenticated && state.shouldRedirectToHome) {
-          // Trigger navigation to home and then reset the flag
           Future.delayed(Duration.zero, () {
             if (context.mounted) {
               context.go('/home?loginSuccess=true');
               viewModel.resetRedirectFlag();
             }
           });
+        }
+        if (state is ProfileUnauthenticated &&
+            state.errorMessage != null &&
+            state.showLoginView) {
+          context.snackbarWarning(state.errorMessage!);
         }
       },
       child: Builder(
@@ -192,7 +196,7 @@ class ProfileView extends MasterViewCubit<ProfileViewModel, ProfileState> {
                   mainAxisAlignment: MainAxisAlignment.center,
                   children: [
                     LogoHeaderWidget(isSignUp: !state.showLoginView),
-                    if (state.errorMessage != null) ...[
+                    if (state.errorMessage != null && !state.showLoginView) ...[
                       OsmeaComponents.text(
                         state.errorMessage!,
                         color: state.errorMessage!.startsWith('Success')


### PR DESCRIPTION
## 📋 PR Description

This PR improves validation and error handling in the `profile_view` for both login and signup flows. It covers two commits:

**`feat` (08106f7):** Added email format validation (checks for `@` character) to the login function. Email and password fields are now trimmed before use. Snackbar notifications for `ProfileUnauthenticated` state are now conditionally shown based on `showLoginView`; errors are displayed as a snackbar on the login screen and as inline text on the signup screen.

**`refactor` (c839262):** Applied the same email format validation to the signup function. Added `showLoginView: false` consistently to all `ProfileUnauthenticated` calls to ensure correct state management. Removed the redundant inline error message widget from the signup view; errors are now shown exclusively via snackbar.

---

## ✅ Checklist
- [x] Code follows the project standards and guidelines.
- [x] Relevant unit tests are written and all tests are passing.
- [x] Test coverage is adequate for the changes.
- [x] Any unnecessary files or debug statements have been removed.
- [x] Documentation is updated where necessary.
- [ ] The PR has been reviewed by at least one team member before merging.

---

## 🛠 Steps to Test

1. Run the app and navigate to the profile screen.
2. **Login — empty field validation:** Leave the email or password field empty and attempt to log in → `"Please enter email and password."` snackbar should appear.
3. **Login — email format validation:** Enter an email without `@` (e.g. `testexample.com`) and attempt to log in → `"Please enter a valid email address."` snackbar should appear.
4. **Login — success flow:** Log in with valid credentials → You should be redirected to the home screen.
5. **Signup — empty field validation:** Leave any field empty and attempt to sign up → `"Please fill all fields."` snackbar should appear.
6. **Signup — email format validation:** Enter an email without `@` and attempt to sign up → `"Please enter a valid email address."` snackbar should appear.
7. **Signup — password mismatch validation:** Enter different values for password and confirm password → `"Passwords do not match."` snackbar should appear.
8. Switch between the login and signup screens and verify that error messages appear correctly as snackbars, and that the old inline error text widget is no longer visible.